### PR TITLE
feat(server): add basic routing and HTML rendering for index page

### DIFF
--- a/src/surtoget.gleam
+++ b/src/surtoget.gleam
@@ -1,7 +1,9 @@
 import gleam/erlang/process
-import gleam/io
+import lustre/attribute.{attribute, href, rel}
+import lustre/element
+import lustre/element/html.{html}
 import mist
-import wisp
+import wisp.{type Request, type Response}
 import wisp/wisp_mist
 
 pub fn main() -> Nil {
@@ -9,10 +11,35 @@ pub fn main() -> Nil {
   wisp.configure_logger()
 
   let assert Ok(_) =
-    wisp_mist.handler(fn(_) { todo }, secret_key_base)
+    wisp_mist.handler(route_request, secret_key_base)
     |> mist.new
     |> mist.port(8000)
     |> mist.start()
 
   process.sleep_forever()
+}
+
+fn route_request(req: Request) -> Response {
+  case wisp.path_segments(req) {
+    [] | ["home"] | ["index"] -> render_index()
+    _ -> wisp.not_found()
+  }
+}
+
+fn render_index() -> Response {
+  let index_page: element.Element(msg) =
+    html([attribute("lang", "en")], [
+      html.head([], [
+        html.title([], "Surtoget"),
+        html.link([href("/css/main.css"), rel("stylesheet")]),
+        html.meta([
+          attribute("content", "width=device-width, initial-scale=1.0"),
+          attribute.name("viewport"),
+        ]),
+      ]),
+      html.body([], [html.h1([], [html.text("Velkommen til Surtoget!")])]),
+    ])
+  index_page
+  |> element.to_string_tree
+  |> wisp.html_response(200)
 }


### PR DESCRIPTION
Replace placeholder handler with a real request router that serves the
index page at root, /home, and /index paths. Implement an HTML renderer
using Lustre to generate a simple index page with proper head elements
and a welcome message. This change sets up a foundation for handling
requests and serving HTML content, improving the server's functionality.