### PR TITLE
feat: add image caching and update dependencies

### DIFF
--- a/gleam.toml
+++ b/gleam.toml
@@ -22,6 +22,9 @@ gleam_erlang = ">= 1.2.0 and < 2.0.0"
 gleam_json = ">= 3.0.2 and < 4.0.0"
 gleam_otp = ">= 1.0.0 and < 2.0.0"
 snag = ">= 1.1.0 and < 2.0.0"
+gleam_crypto = ">= 1.5.1 and < 2.0.0"
+vix = ">= 0.30.0 and < 1.0.0"
+req = ">= 0.5.15 and < 1.0.0"
 
 [dev-dependencies]
 gleeunit = ">= 1.0.0 and < 2.0.0"

--- a/manifest.toml
+++ b/manifest.toml
@@ -2,10 +2,13 @@
 # You typically do not need to edit this file
 
 packages = [
+  { name = "cc_precompiler", version = "0.1.10", build_tools = ["mix"], requirements = ["elixir_make"], otp_app = "cc_precompiler", source = "hex", outer_checksum = "F6E046254E53CD6B41C6BACD70AE728011AA82B2742A80D6E2214855C6E06B22" },
   { name = "directories", version = "1.2.0", build_tools = ["gleam"], requirements = ["envoy", "gleam_stdlib", "platform", "simplifile"], otp_app = "directories", source = "hex", outer_checksum = "D13090CFCDF6759B87217E8DDD73A75903A700148A82C1D33799F333E249BF9E" },
+  { name = "elixir_make", version = "0.9.0", build_tools = ["mix"], requirements = [], otp_app = "elixir_make", source = "hex", outer_checksum = "DB23D4FD8B757462AD02F8AA73431A426FE6671C80B200D9710CAF3D1DD0FFDB" },
   { name = "envoy", version = "1.0.2", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "envoy", source = "hex", outer_checksum = "95FD059345AA982E89A0B6E2A3BF1CF43E17A7048DCD85B5B65D3B9E4E39D359" },
   { name = "exception", version = "2.1.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "exception", source = "hex", outer_checksum = "329D269D5C2A314F7364BD2711372B6F2C58FA6F39981572E5CA68624D291F8C" },
   { name = "filepath", version = "1.1.2", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "filepath", source = "hex", outer_checksum = "B06A9AF0BF10E51401D64B98E4B627F1D2E48C154967DA7AF4D0914780A6D40A" },
+  { name = "finch", version = "0.20.0", build_tools = ["mix"], requirements = ["mime", "mint", "nimble_options", "nimble_pool", "telemetry"], otp_app = "finch", source = "hex", outer_checksum = "2658131A74D051AABFCBA936093C903B8E89DA9A1B63E430BEE62045FA9B2EE2" },
   { name = "gleam_crypto", version = "1.5.1", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_crypto", source = "hex", outer_checksum = "50774BAFFF1144E7872814C566C5D653D83A3EBF23ACC3156B757A1B6819086E" },
   { name = "gleam_erlang", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_erlang", source = "hex", outer_checksum = "F91CE62A2D011FA13341F3723DB7DB118541AAA5FE7311BD2716D018F01EF9E3" },
   { name = "gleam_http", version = "4.1.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_http", source = "hex", outer_checksum = "DB25DFC8530B64B77105405B80686541A0D96F7E2D83D807D6B2155FB9A8B1B8" },
@@ -18,18 +21,27 @@ packages = [
   { name = "gramps", version = "3.0.2", build_tools = ["gleam"], requirements = ["gleam_crypto", "gleam_erlang", "gleam_http", "gleam_stdlib"], otp_app = "gramps", source = "hex", outer_checksum = "D213EEE41B467853E1FB9AAC204D2CB1AB301C84E8F7C1DF3307128221AB53BF" },
   { name = "houdini", version = "1.1.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "houdini", source = "hex", outer_checksum = "5BA517E5179F132F0471CB314F27FE210A10407387DA1EA4F6FD084F74469FC2" },
   { name = "hpack_erl", version = "0.3.0", build_tools = ["rebar3"], requirements = [], otp_app = "hpack", source = "hex", outer_checksum = "D6137D7079169D8C485C6962DFE261AF5B9EF60FBC557344511C1E65E3D95FB0" },
+  { name = "hpax", version = "1.0.3", build_tools = ["mix"], requirements = [], otp_app = "hpax", source = "hex", outer_checksum = "8EAB6E1CFA8D5918C2CE4BA43588E894AF35DBD8E91E6E55C817BCA5847DF34A" },
+  { name = "jason", version = "1.4.4", build_tools = ["mix"], requirements = ["decimal"], otp_app = "jason", source = "hex", outer_checksum = "C5EB0CAB91F094599F94D55BC63409236A8EC69A21A67814529E8D5F6CC90B3B" },
   { name = "logging", version = "1.3.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "logging", source = "hex", outer_checksum = "1098FBF10B54B44C2C7FDF0B01C1253CAFACDACABEFB4B0D027803246753E06D" },
   { name = "lustre", version = "5.2.1", build_tools = ["gleam"], requirements = ["gleam_erlang", "gleam_json", "gleam_otp", "gleam_stdlib", "houdini"], otp_app = "lustre", source = "hex", outer_checksum = "DCD121F8E6B7E179B27D9A8AEB6C828D8380E26DF2E16D078511EDAD1CA9F2A7" },
   { name = "marceau", version = "1.3.0", build_tools = ["gleam"], requirements = [], otp_app = "marceau", source = "hex", outer_checksum = "2D1C27504BEF45005F5DFB18591F8610FB4BFA91744878210BDC464412EC44E9" },
+  { name = "mime", version = "2.0.7", build_tools = ["mix"], requirements = [], otp_app = "mime", source = "hex", outer_checksum = "6171188E399EE16023FFC5B76CE445EB6D9672E2E241D2DF6050F3C771E80CCD" },
+  { name = "mint", version = "1.7.1", build_tools = ["mix"], requirements = ["castore", "hpax"], otp_app = "mint", source = "hex", outer_checksum = "FCEBA0A4D0F24301DDEE3024AE116DF1C3F4BB7A563A731F45FDFEB9D39A231B" },
   { name = "mist", version = "5.0.2", build_tools = ["gleam"], requirements = ["gleam_erlang", "gleam_http", "gleam_otp", "gleam_stdlib", "gleam_yielder", "glisten", "gramps", "hpack_erl", "logging"], otp_app = "mist", source = "hex", outer_checksum = "0716CE491EA13E1AA1EFEC4B427593F8EB2B953B6EBDEBE41F15BE3D06A22918" },
+  { name = "nimble_options", version = "1.1.1", build_tools = ["mix"], requirements = [], otp_app = "nimble_options", source = "hex", outer_checksum = "821B2470CA9442C4B6984882FE9BB0389371B8DDEC4D45A9504F00A66F650B44" },
+  { name = "nimble_pool", version = "1.1.0", build_tools = ["mix"], requirements = [], otp_app = "nimble_pool", source = "hex", outer_checksum = "AF2E4E6B34197DB81F7AAD230C1118EAC993ACC0DAE6BC83BAC0126D4AE0813A" },
   { name = "platform", version = "1.0.0", build_tools = ["gleam"], requirements = [], otp_app = "platform", source = "hex", outer_checksum = "8339420A95AD89AAC0F82F4C3DB8DD401041742D6C3F46132A8739F6AEB75391" },
+  { name = "req", version = "0.5.15", build_tools = ["mix"], requirements = ["brotli", "ezstd", "finch", "jason", "mime", "nimble_csv", "plug"], otp_app = "req", source = "hex", outer_checksum = "A6513A35FAD65467893CED9785457E91693352C70B58BBC045B47E5EB2EF0C53" },
   { name = "simplifile", version = "2.3.0", build_tools = ["gleam"], requirements = ["filepath", "gleam_stdlib"], otp_app = "simplifile", source = "hex", outer_checksum = "0A868DAC6063D9E983477981839810DC2E553285AB4588B87E3E9C96A7FB4CB4" },
   { name = "snag", version = "1.1.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "snag", source = "hex", outer_checksum = "7E9F06390040EB5FAB392CE642771484136F2EC103A92AE11BA898C8167E6E17" },
   { name = "telemetry", version = "1.3.0", build_tools = ["rebar3"], requirements = [], otp_app = "telemetry", source = "hex", outer_checksum = "7015FC8919DBE63764F4B4B87A95B7C0996BD539E0D499BE6EC9D7F3875B79E6" },
+  { name = "vix", version = "0.35.0", build_tools = ["mix", "make"], requirements = ["cc_precompiler", "elixir_make", "kino"], otp_app = "vix", source = "hex", outer_checksum = "A3E80067A89D0631B6CF2B93594E03C1B303A2C7CDDBBDD28040750D521984E5" },
   { name = "wisp", version = "1.8.0", build_tools = ["gleam"], requirements = ["directories", "exception", "gleam_crypto", "gleam_erlang", "gleam_http", "gleam_json", "gleam_stdlib", "houdini", "logging", "marceau", "mist", "simplifile"], otp_app = "wisp", source = "hex", outer_checksum = "0FE9049AFFB7C8D5FC0B154EEE2704806F4D51B97F44925D69349B3F4F192957" },
 ]
 
 [requirements]
+gleam_crypto = { version = ">= 1.5.1 and < 2.0.0" }
 gleam_erlang = { version = ">= 1.2.0 and < 2.0.0" }
 gleam_http = { version = ">= 4.1.0 and < 5.0.0" }
 gleam_json = { version = ">= 3.0.2 and < 4.0.0" }
@@ -38,5 +50,7 @@ gleam_stdlib = { version = ">= 0.44.0 and < 2.0.0" }
 gleeunit = { version = ">= 1.0.0 and < 2.0.0" }
 lustre = { version = ">= 5.2.1 and < 6.0.0" }
 mist = { version = ">= 5.0.2 and < 6.0.0" }
+req = { version = ">= 0.5.15 and < 1.0.0" }
 snag = { version = ">= 1.1.0 and < 2.0.0" }
+vix = { version = ">= 0.30.0 and < 1.0.0" }
 wisp = { version = ">= 1.8.0 and < 2.0.0" }

--- a/src/image_cache.gleam
+++ b/src/image_cache.gleam
@@ -1,0 +1,113 @@
+import gleam/bool
+import gleam/bytes_tree
+import gleam/dict
+import gleam/erlang/process
+import gleam/int
+import gleam/otp/actor
+import gleam/string
+import news
+
+pub type Image
+
+@external(erlang, "Elixir.VixHelper", "to_bit_array")
+fn to_bit_array_ffi(img: Image, format: String) -> bit_array
+
+@external(erlang, "Elixir.VixHelper", "fetch_image")
+fn fetch_image_ffi(url: String) -> Result(Image, String)
+
+type ImageFormat {
+  JPEG(quality: Int, keep_metadata: Bool)
+  PNG
+  WebP(quality: Int, keep_metadata: Bool)
+  AVIF(quality: Int, keep_metadata: Bool)
+}
+
+pub type ImageCacheMessage {
+  GetCachedImage(String, process.Subject(Result(Image, Nil)))
+  PutCachedImage(String, Image)
+}
+
+type State {
+  State(cache: dict.Dict(String, Image))
+}
+
+fn to_bit_array(img: Image, format: ImageFormat) -> BitArray {
+  to_bit_array_ffi(img, image_format_to_string(format))
+}
+
+fn image_format_to_string(format: ImageFormat) -> String {
+  case format {
+    JPEG(quality:, keep_metadata:) ->
+      ".jpeg" <> format_common_options(quality, keep_metadata)
+    PNG -> ".png"
+    WebP(quality:, keep_metadata:) ->
+      ".webp" <> format_common_options(quality, keep_metadata)
+    AVIF(quality:, keep_metadata:) ->
+      ".avif" <> format_common_options(quality, keep_metadata)
+  }
+}
+
+fn format_common_options(quality, keep_metadata) {
+  "[Q="
+  <> int.to_string(quality)
+  <> ",strip="
+  <> bool.to_string(!keep_metadata) |> string.lowercase
+  <> "]"
+}
+
+fn handle_message(
+  state: State,
+  message: ImageCacheMessage,
+) -> actor.Next(State, ImageCacheMessage) {
+  let State(cache) = state
+
+  case message {
+    GetCachedImage(id, reply_to) -> {
+      process.send(reply_to, dict.get(cache, id))
+      actor.continue(state)
+    }
+    PutCachedImage(id, image) -> {
+      let new_cache = dict.insert(cache, id, image)
+      actor.continue(State(new_cache))
+    }
+  }
+}
+
+pub fn start() -> Result(
+  actor.Started(process.Subject(ImageCacheMessage)),
+  actor.StartError,
+) {
+  actor.new(State(dict.new()))
+  |> actor.on_message(handle_message)
+  |> actor.start()
+}
+
+pub fn get_cached_image(
+  id: String,
+  actor: process.Subject(ImageCacheMessage),
+) -> Result(bytes_tree.BytesTree, Nil) {
+  let image_type = JPEG(80, False)
+  case process.call(actor, 100, fn(reply_to) { GetCachedImage(id, reply_to) }) {
+    Ok(image) ->
+      Ok(
+        image
+        |> to_bit_array(image_type)
+        |> bytes_tree.from_bit_array(),
+      )
+    Error(_) -> Error(Nil)
+  }
+}
+
+pub fn fetch_and_cache_image(
+  article: news.NewsArticle,
+  actor: process.Subject(ImageCacheMessage),
+) -> Result(bytes_tree.BytesTree, Nil) {
+  let image_id: String = news.get_image_id(article)
+  case fetch_image_ffi(article.external_url) {
+    Ok(image) -> {
+      process.send(actor, PutCachedImage(image_id, image))
+      get_cached_image(image_id, actor)
+    }
+    Error(_) -> Error(Nil)
+  }
+}

--- a/src/news.gleam
+++ b/src/news.gleam
@@ -1,78 +1,72 @@
+import gleam/bit_array
 import gleam/list
 import lustre/attribute.{alt, class, href, rel, src, target}
 import lustre/element.{type Element}
 import lustre/element/html
 
+import gleam/crypto
+import gleam/int
+import gleam/result
+import gleam/string
+
 pub type NewsArticle {
   NewsArticle(
     title: String,
     description: String,
-    image_url: String,
     external_url: String,
     date: String,
   )
 }
 
 import gleam/dict
-import gleam/int
-import gleam/result
-import gleam/string
 
 pub fn get_news_articles() -> List(NewsArticle) {
   let articles = [
     NewsArticle(
       title: "Signalfeil får konsekvenser for Sørlandsbanen",
       description: "En signalfeil i Oslo skaper forsinkelser og innstillinger for Sørlandsbanen, som går til og fra Oslo. Ingen tog kan passere Oslo på grunn av feilen.",
-      image_url: "/priv/static/news/signalfeil_sorlandsbanen.jpg",
       external_url: "https://www.nrk.no/sorlandet/signalfeil-far-konsekvenser-for-sorlandsbanen-1.17340909",
       date: "15. mars 2025",
     ),
     NewsArticle(
       title: "Store togproblemer på Sørlandsbanen",
       description: "Det er meldt om store problemer for tog mellom Marnardal og Audnedal. Mye rim på kjøretråden gir dårlig kontakt mellom tog og kjøretråd, noe som fører til strømproblemer.",
-      image_url: "/priv/static/news/togproblemer_sorlandsbanen.jpg",
       external_url: "https://www.nrk.no/sorlandet/store-togproblemer-pa-sorlandsbanen-1.17189263",
       date: "10. november 2024",
     ),
     NewsArticle(
       title: "Vy tar over Sørlandsbanen - Go-Ahead Nordic vrakes",
       description: "Den statseide togselskapet Vy tar over Sørlandsbanen, Arendalsbanen og Jærbanen fra Go-Ahead Nordic fra desember 2027.",
-      image_url: "/priv/static/news/vy_tar_over_sorlandsbanen.jpg",
       external_url: "https://www.nrk.no/sorlandet/vy-tar-over-sorlandsbanen-_-go-ahead-nordic-vrakes-1.17094076",
       date: "25. oktober 2024",
     ),
     NewsArticle(
       title: "Flere ordførere i Telemark kjemper for å få tilbake stopp på Sørlandsbanen",
       description: "Fire ordførere fra Telemark har sendt et brev til stortingspolitikerne der de kritiserer Bane Nor for å ha fjernet stopp på Sørlandsbanen, noe de mener har forverret punktligheten.",
-      image_url: "/priv/static/news/ordforere_telemark.jpg",
       external_url: "https://www.nrk.no/vestfoldogtelemark/flere-ordforere-i-telemark-kjemper-for-a-fa-tilbake-stopp-pa-sorlandsbanen-1.17092301",
       date: "28. oktober 2024",
     ),
     NewsArticle(
       title: "Fikk tre timer i Drangedal",
       description: "Reisende med toget fra Stavanger til Oslo søndag ettermiddag fikk anledning til å studere omgivelsene rundt stasjonen i Prestestranda i rundt tre timer før turen kunne gå videre.",
-      image_url: "/priv/static/news/drangedal_stop.jpg",
       external_url: "https://www.drangedalsposten.no/fikk-tre-timer-i-drangedal/s/5-164-34904",
       date: "16. juni 2025",
     ),
     NewsArticle(
       title: "Stor aktør på Jærbanen trekker seg: Frykter mer buss for tog",
       description: "Selskapet som vedlikeholder togene på Sørlandsbanen, terminerte kontrakten etter store økonomiske tap. Nå overtar Go-Ahead arbeidet selv.",
-      image_url: "/priv/static/news/jaerbanen_aktør_trekker_seg.jpg",
       external_url: "https://www.aftenbladet.no/lokalt/i/dRe2j1/stor-aktoer-paa-jaerbanen-trekker-seg-frykter-mer-buss-for-tog",
       date: "26. mai 2025",
     ),
     NewsArticle(
       title: "Buss for tog i sommar",
       description: "Sidan pendlarane har ferie og det er færre som tar tog, nyttar Bane Nor moglegheitene til vedlikehalds- og byggearbeid på togstrekningane.",
-      image_url: "/priv/static/news/buss_for_tog_sommar.jpg",
       external_url: "https://www.nrk.no/vestfoldogtelemark/buss-for-tog-i-sommar-1.17424797",
       date: "20. mai 2025",
     ),
     NewsArticle(
       title: "Sørlandsbanen: Har aldri vært verre",
       description: "Sørlandsbanen har lavest punktlighet – tiltakene gir liten effekt så langt.",
-      image_url: "/priv/static/news/sorlandsbanen_aldri_verre.jpg",
       external_url: "https://www.dalane-tidende.no/sorlandsbanen-har-aldri-vart-verre/s/5-101-741316",
       date: "19. januar 2025",
     ),
@@ -124,6 +118,21 @@ fn parse_date(date_string: String) -> Result(String, Nil) {
   }
 }
 
+pub fn get_image_id(article: NewsArticle) -> String {
+  crypto.hash(crypto.Sha1, bit_array.from_string(article.external_url))
+  |> bit_array.base16_encode()
+}
+
+pub fn get_image_url(article: NewsArticle) -> String {
+  "news/images/" <> get_image_id(article)
+}
+
+pub fn find_article_by_image_id(image_id: String) -> Result(NewsArticle, Nil) {
+  get_news_articles()
+  |> list.filter(fn(article) { get_image_id(article) == image_id })
+  |> list.first()
+}
+
 pub fn render(articles: List(NewsArticle)) -> Element(a) {
   html.div([class("py-12 bg-gray-50")], [
     html.div([class("max-w-7xl mx-auto px-4 sm:px-6 lg:px-8")], [
@@ -160,7 +169,7 @@ pub fn render(articles: List(NewsArticle)) -> Element(a) {
             [
               html.div([class("md:w-1/3")], [
                 html.img([
-                  src(article.image_url),
+                  src(get_image_url(article)),
                   alt(article.title),
                   class("w-full h-full object-cover"),
                 ]),

--- a/src/news_page.gleam
+++ b/src/news_page.gleam
@@ -24,7 +24,7 @@ pub fn render(articles: List(NewsArticle)) -> Element(a) {
           ],
           [
             html.img([
-              attribute.src(article.image_url),
+              attribute.src(news.get_image_url(article)),
               attribute.alt(article.title),
               attribute.class("w-full h-48 object-cover"),
             ]),

--- a/src/vix_helper.ex
+++ b/src/vix_helper.ex
@@ -1,0 +1,30 @@
+defmodule VixHelper do
+  alias Vix.Vips.{Image}
+
+  def read(path) do
+    Path.expand(path) |> Image.new_from_file()
+  end
+
+  def to_bit_array(image, format) do
+    Image.write_to_stream(image, format) |> Enum.into(<<>>)
+  end
+
+  def fetch_image_bytes(url, format \\ "png") do
+    with {:ok, %Req.Response{status: 200, body: body}} <- Req.get(url),
+         {:ok, image} <- Vix.Vips.Image.new_from_buffer(body, ""),
+         {:ok, binary} <- Vix.Vips.Image.write_to_buffer(image, "." <> format) do
+      {:ok, binary}
+    else
+      _ -> {:error, "Could not fetch or convert image"}
+    end
+  end
+
+  def fetch_image(url) do
+    with {:ok, %Req.Response{status: 200, body: body}} <- Req.get(url),
+         {:ok, image} <- Vix.Vips.Image.new_from_buffer(body, "") do
+      {:ok, image}
+    else
+      _ -> {:error, "Failed to fetch or decode image"}
+    end
+  end
+end


### PR DESCRIPTION
Replace direct article image URLs with cached image retrieval to improve
performance and reduce external requests. Introduce an image cache process
to serve news images efficiently.

Add multiple new dependencies including req, finch, jason, and vix to support
HTTP client functionality and image processing. Update manifest.toml to
include these packages and their requirements.

Refactor request handling to pass image cache actor and handle image fetch
requests under /news/images/:id route, serving cached images or falling
back to original source if not cached.