### PR TITLE
feat-monthly-stats-yearly-averages

### DIFF
--- a/priv/static/charts.js
+++ b/priv/static/charts.js
@@ -22,7 +22,7 @@ document.addEventListener("DOMContentLoaded", () => {
 
     const width = chartWidth * 0.7;
     const height = chartHeight * 0.7;
-    const radius = (Math.min(width, height) / 2) * 0.8;
+    const radius = (Math.min(width, height) / 2) * 0.9;
 
     const svg = chartWrapper
       .append("svg")


### PR DESCRIPTION
- Added MonthlyStats type with sample data for January, February, and May.
- Implemented functions to calculate yearly average blame stats and on-time percentages by aggregating monthly data.
- Updated overall and blame stats retrieval to use computed yearly averages for the "this_year" period.
- Reduced chart label font size from 16px to 14px for better readability.
- Increased pie chart radius for improved visibility.
- Updated tab label to reflect accurate data period ("Siste rapport (Mai)").
- Fixed capitalization in chart labels for consistency.
- Displayed not_on_time percentage with one decimal precision and applied gradient text styling.