### PR TITLE
ci: add GitHub Actions workflow for testing on main branch

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,21 @@
+name: Test
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: erlef/setup-beam@v1
+        with:
+          otp-version: "27.1.2"
+          gleam-version: "1.11.0"
+          rebar3-version: "3"
+          elixir-version: "1.18.1"
+      - run: gleam deps download
+      - run: gleam format --check src


### PR DESCRIPTION
Add a new GitHub Actions workflow to run tests on push and pull
requests targeting the main branch. The workflow sets up the
environment with specific versions of OTP, Gleam, Rebar3, and Elixir,
downloads Gleam dependencies, and checks code formatting to ensure
code quality and consistency.