### PR TITLE
chore: add initial fly.toml configuration for deployment

### DIFF
--- a/fly.toml
+++ b/fly.toml
@@ -1,0 +1,25 @@
+app = 'surtoget'
+primary_region = 'arn'
+
+[build]
+
+[http_service]
+internal_port = 8000
+force_https = true
+auto_stop_machines = 'suspend'
+auto_start_machines = true
+min_machines_running = 0
+processes = ['app']
+
+[[vm]]
+memory = '512mb'
+cpu_kind = 'shared'
+cpus = 1
+memory_mb = 512
+
+[[http_service.checks]]
+grace_period = "5s"
+interval = "30s"
+method = "GET"
+timeout = "5s"
+path = "/health"


### PR DESCRIPTION
Add fly.toml with app name, primary region, and build settings.  
Configure HTTP service with internal port, HTTPS enforcement, and  
auto start/stop machine behavior. Define VM resources and health  
check parameters to ensure proper app monitoring and resource use.