### PR TITLE
fix: correct label positioning in pie chart rendering

### DIFF
--- a/priv/javascript/main.js
+++ b/priv/javascript/main.js
@@ -156,7 +156,7 @@ document.addEventListener("DOMContentLoaded", () => {
           .attr("transform", function (d) {
             const pos = outerArc.centroid(d);
             const midangle = d.startAngle + (d.endAngle - d.startAngle) / 2;
-            pos[0] = radius * 1.1 * (midangle < Math.PI ? 1 : -1);
+            pos[0] = radius * (midangle < Math.PI ? 1 : -1);
             return `translate(${pos})`;
           })
           .text(d.data.label)


### PR DESCRIPTION
Adjust label horizontal position calculation by removing the 1.1 
multiplier from the radius. This change aligns labels closer to the 
pie chart edge, improving visual accuracy and readability.