### PR TITLE
feat-preload-serve-cached-images

### DIFF
--- a/src/surtoget.gleam
+++ b/src/surtoget.gleam
@@ -28,7 +28,6 @@ pub fn main() -> Nil {
   let secret_key_base = wisp.random_string(64)
   wisp.configure_logger()
   let assert Ok(cache) = image_cache.start()
-  process.send(cache.data, image_cache.CacheImages)
   let assert Ok(_) =
     wisp_mist.handler(handle_request(_, cache.data), secret_key_base)
     |> mist.new()


### PR DESCRIPTION
- Preload and serve cached images on startup to improve performance.
- Replace on-demand image fetching with serving a static placeholder on cache misses.
- Batch load all images at once for simplified cache management.
- Add async image caching with resizing to a max width of 600 pixels using Vix FFI.
- Refactor message handling by replacing CacheImages with SetCache.
- Add debug logging for cache operations and fallback to default image on load failure.