### PR TITLE
docs: update content to clarify focus on Sørlandsbanen

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,15 @@
   <img src="./priv/static/surtoget_logo.png" alt="surtoget logo" width="200px">
 </p>
 
+Ah, Sørlandsbanen. The train line that makes you question your life choices.
+If you've ever found yourself stranded in the middle of nowhere, wondering why
+you didn't just take the bus, this project is for you.
+
+Surtoget is a place to share your pain, laugh at the absurdity of it all,
+and maybe, just maybe, find some solidarity in our shared suffering.
+
+Feel free to check out the website here: [surtoget.no](https://surtoget.no)
+
 ## Prerequisites
 
 To run this project, you need:

--- a/src/about.gleam
+++ b/src/about.gleam
@@ -29,7 +29,7 @@ pub fn render() -> Element(msg) {
       ]),
       html.p([], [
         html.text(
-          "Surtoget.no er et forsøk på å belyse problemet. For det kan da umulig være bare jeg som har det sånn? Målet er å skape en plattform for informasjon, og forhåpentligvis, en arena for samtale. Eller i det minste, et sted å få ut litt frustrasjon.",
+          "Surtoget.no er et forsøk på å belyse problemet. For det kan da umulig være bare jeg som har det sånn? Målet er å skape en plattform for informasjon, og forhåpentligvis, kunne skape litt samtale rundt tilstanden til Sørlandsbanen. Eller i det minste, et sted å få ut litt frustrasjon.",
         ),
       ]),
     ]),

--- a/src/faq.gleam
+++ b/src/faq.gleam
@@ -38,6 +38,22 @@ pub fn render() -> Element(msg) {
       [],
     ),
     Question(
+      "Hvorfor bare Sørlandsbanen?",
+      [
+        "Fordi det er Sørlandsbanen som frustrerer meg personlig 🤷🏻‍♂️",
+        "Når det er sagt så tror jeg at Sørlandsbanen trekker den generelle punktlighetsstatistikken ganske langt ned, så da er Sørlandsbanen kanskje et OK fokus og ha.",
+      ],
+      [],
+    ),
+    Question(
+      "Hvem har skylda for at Sørlandsbanen er så dårlig?!",
+      [
+        "Det skulle jeg også gjerne visst. Jeg er dessverre ikke noe ekspert på dette, men jeg håper å få lagt inn mer informasjon om hvorfor ting har blitt som de har blitt.",
+        "Om jeg må komme med en teori så ville jeg pekt på en kombinasjon av privatisering, uvillighet til å modernisere infrastruktur, mangel på togsett, tvilsomme kjøpt av tog uten snøplog og nedprioritering i budsjetter. Alle disse tingene har nok hatt en påvirkning og gjort jernbanenorge dårligere.",
+      ],
+      [],
+    ),
+    Question(
       "Hvilke teknologier brukes?",
       [
         "Surtoget er bygget med følgende teknologier:",


### PR DESCRIPTION
Clarify that Surtoget.no specifically targets issues with Sørlandsbanen,
highlighting it as a personal frustration and a significant factor in overall
punctuality statistics. Add FAQ entries explaining why Sørlandsbanen is the
focus and discuss possible reasons for its poor performance. Enhance README
with a humorous introduction to set the tone and invite users to the site.