### PR TITLE
fix(news): render all news articles instead of only top 3

### DIFF
--- a/src/surtoget.gleam
+++ b/src/surtoget.gleam
@@ -57,8 +57,7 @@ fn route_request(
     ["faq"] -> render_page(faq.render())
     ["health"] -> wisp.ok()
     ["favicon.ico"] -> get_favicon(req)
-    ["news"] ->
-      news.get_news_articles() |> list.take(3) |> news.render() |> render_page()
+    ["news"] -> news.get_news_articles() |> news.render() |> render_page()
     ["news", "images", image_id] ->
       handle_news_image_request(image_id, req, image_cache)
     _ -> wisp.not_found()


### PR DESCRIPTION
Remove the limit of taking only 3 news articles before rendering.
This change ensures that all available news articles are displayed on
the news page, providing users with complete and up-to-date content.