### PR TITLE
feat: add Simple Analytics script for tracking

### DIFF
--- a/src/faq.gleam
+++ b/src/faq.gleam
@@ -60,6 +60,8 @@ pub fn render() -> Element(msg) {
         "- Gleam: Et moderne og brukervennlig programmeringsspråk for backenden.",
         "- Lustre: Et webrammeverk for Gleam.",
         "- Tailwind CSS: For design og styling.",
+        "- Simpleanalytics: For statistikk på besøkende på siden",
+        "- fly.io: Der nettsiden kjøres",
         "Kildekoden er åpen og tilgjengelig på GitHub.",
       ],
       [
@@ -67,6 +69,8 @@ pub fn render() -> Element(msg) {
           "https://github.com/atomfinger/surtoget",
           "https://github.com/atomfinger/surtoget",
         ),
+        #("fly.io/legal/privacy-policy.", "fly.io privacy policy"),
+        #("https://docs.simpleanalytics.com/privacy", "Simpleanalytics"),
       ],
     ),
     Question(

--- a/src/surtoget.gleam
+++ b/src/surtoget.gleam
@@ -149,6 +149,13 @@ fn render_head(
     ]),
     html.script([src("/javascript/main.js"), attribute("defer", "")], ""),
     html.script([src("https://d3js.org/d3.v7.min.js")], ""),
+    html.script(
+      [
+        attribute.src("https://scripts.simpleanalyticscdn.com/latest.js"),
+        attribute("async", ""),
+      ],
+      "",
+    ),
   ]
 
   html.head([], list.append(common_elements, extra_elements))


### PR DESCRIPTION
Include the Simple Analytics script asynchronously to enable
privacy-friendly user analytics on the site. This enhances
insights into user behavior without impacting page load times.