### PR TITLE
fix(render_page): remove external d3.js script from head

### DIFF
--- a/src/surtoget.gleam
+++ b/src/surtoget.gleam
@@ -164,9 +164,7 @@ fn render_head(
 fn render_page(content: Element(msg)) -> response.Response(wisp.Body) {
   let index_page: Element(msg) =
     html.html([attribute("lang", "no")], [
-      render_head("Surtoget - Sørlandsbanens sanne ansikt", [
-        html.script([src("https://d3js.org/d3.v7.min.js")], ""),
-      ]),
+      render_head("Surtoget - Sørlandsbanens sanne ansikt", []),
       html.body([class("bg-gray-50 text-gray-800")], [
         html.div(
           [class("container mx-auto px-4 min-w-[330px] max-w-[1024px]")],


### PR DESCRIPTION
Remove the inclusion of the d3.js script from the page head to reduce
external dependencies and improve page load performance. The script
was not used in the current rendering, so this cleanup simplifies the
HTML output.