### PR TITLE
feat-entur-delay-detection

### DIFF
--- a/gleam.toml
+++ b/gleam.toml
@@ -27,6 +27,9 @@ vix = ">= 0.30.0 and < 1.0.0"
 req = ">= 0.5.15 and < 1.0.0"
 simplifile = ">= 2.3.0 and < 3.0.0"
 marceau = ">= 1.3.0 and < 2.0.0"
+gleamql = ">= 0.4.0 and < 1.0.0"
+gtempo = ">= 7.2.2 and < 8.0.0"
+gleam_hackney = ">= 1.3.1 and < 2.0.0"
 
 [dev-dependencies]
 gleeunit = ">= 1.0.0 and < 2.0.0"

--- a/manifest.toml
+++ b/manifest.toml
@@ -3,39 +3,55 @@
 
 packages = [
   { name = "cc_precompiler", version = "0.1.10", build_tools = ["mix"], requirements = ["elixir_make"], otp_app = "cc_precompiler", source = "hex", outer_checksum = "F6E046254E53CD6B41C6BACD70AE728011AA82B2742A80D6E2214855C6E06B22" },
+  { name = "certifi", version = "2.15.0", build_tools = ["rebar3"], requirements = [], otp_app = "certifi", source = "hex", outer_checksum = "B147ED22CE71D72EAFDAD94F055165C1C182F61A2FF49DF28BCC71D1D5B94A60" },
   { name = "directories", version = "1.2.0", build_tools = ["gleam"], requirements = ["envoy", "gleam_stdlib", "platform", "simplifile"], otp_app = "directories", source = "hex", outer_checksum = "D13090CFCDF6759B87217E8DDD73A75903A700148A82C1D33799F333E249BF9E" },
   { name = "elixir_make", version = "0.9.0", build_tools = ["mix"], requirements = [], otp_app = "elixir_make", source = "hex", outer_checksum = "DB23D4FD8B757462AD02F8AA73431A426FE6671C80B200D9710CAF3D1DD0FFDB" },
   { name = "envoy", version = "1.0.2", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "envoy", source = "hex", outer_checksum = "95FD059345AA982E89A0B6E2A3BF1CF43E17A7048DCD85B5B65D3B9E4E39D359" },
   { name = "exception", version = "2.1.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "exception", source = "hex", outer_checksum = "329D269D5C2A314F7364BD2711372B6F2C58FA6F39981572E5CA68624D291F8C" },
   { name = "filepath", version = "1.1.2", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "filepath", source = "hex", outer_checksum = "B06A9AF0BF10E51401D64B98E4B627F1D2E48C154967DA7AF4D0914780A6D40A" },
   { name = "finch", version = "0.20.0", build_tools = ["mix"], requirements = ["mime", "mint", "nimble_options", "nimble_pool", "telemetry"], otp_app = "finch", source = "hex", outer_checksum = "2658131A74D051AABFCBA936093C903B8E89DA9A1B63E430BEE62045FA9B2EE2" },
+  { name = "gleam_community_ansi", version = "1.4.3", build_tools = ["gleam"], requirements = ["gleam_community_colour", "gleam_regexp", "gleam_stdlib"], otp_app = "gleam_community_ansi", source = "hex", outer_checksum = "8A62AE9CC6EA65BEA630D95016D6C07E4F9973565FA3D0DE68DC4200D8E0DD27" },
+  { name = "gleam_community_colour", version = "2.0.2", build_tools = ["gleam"], requirements = ["gleam_json", "gleam_stdlib"], otp_app = "gleam_community_colour", source = "hex", outer_checksum = "E34DD2C896AC3792151EDA939DA435FF3B69922F33415ED3C4406C932FBE9634" },
   { name = "gleam_crypto", version = "1.5.1", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_crypto", source = "hex", outer_checksum = "50774BAFFF1144E7872814C566C5D653D83A3EBF23ACC3156B757A1B6819086E" },
   { name = "gleam_erlang", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_erlang", source = "hex", outer_checksum = "F91CE62A2D011FA13341F3723DB7DB118541AAA5FE7311BD2716D018F01EF9E3" },
+  { name = "gleam_hackney", version = "1.3.1", build_tools = ["gleam"], requirements = ["gleam_http", "gleam_stdlib", "hackney"], otp_app = "gleam_hackney", source = "hex", outer_checksum = "0449AADBEBF3E979509A4079EE34B92EEE4162C5A0DC94F3DA2787E4777F6B45" },
   { name = "gleam_http", version = "4.1.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_http", source = "hex", outer_checksum = "DB25DFC8530B64B77105405B80686541A0D96F7E2D83D807D6B2155FB9A8B1B8" },
   { name = "gleam_json", version = "3.0.2", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_json", source = "hex", outer_checksum = "874FA3C3BB6E22DD2BB111966BD40B3759E9094E05257899A7C08F5DE77EC049" },
   { name = "gleam_otp", version = "1.0.0", build_tools = ["gleam"], requirements = ["gleam_erlang", "gleam_stdlib"], otp_app = "gleam_otp", source = "hex", outer_checksum = "7020E652D18F9ABAC9C877270B14160519FA0856EE80126231C505D719AD68DA" },
+  { name = "gleam_regexp", version = "1.1.1", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_regexp", source = "hex", outer_checksum = "9C215C6CA84A5B35BB934A9B61A9A306EC743153BE2B0425A0D032E477B062A9" },
   { name = "gleam_stdlib", version = "0.62.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "DC8872BC0B8550F6E22F0F698CFE7F1E4BDA7312FDEB40D6C3F44C5B706C8310" },
+  { name = "gleam_time", version = "1.4.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_time", source = "hex", outer_checksum = "DCDDC040CE97DA3D2A925CDBBA08D8A78681139745754A83998641C8A3F6587E" },
   { name = "gleam_yielder", version = "1.1.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_yielder", source = "hex", outer_checksum = "8E4E4ECFA7982859F430C57F549200C7749823C106759F4A19A78AEA6687717A" },
+  { name = "gleamql", version = "0.4.0", build_tools = ["gleam"], requirements = ["gleam_json", "gleam_stdlib", "glint"], otp_app = "gleamql", source = "hex", outer_checksum = "9087C7323839646AEC59D4749A9DB771F00D87DA6F041CDC91BC97838A2DC27D" },
   { name = "gleeunit", version = "1.6.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "63022D81C12C17B7F1A60E029964E830A4CBD846BBC6740004FC1F1031AE0326" },
+  { name = "glint", version = "1.2.1", build_tools = ["gleam"], requirements = ["gleam_community_ansi", "gleam_community_colour", "gleam_stdlib", "snag"], otp_app = "glint", source = "hex", outer_checksum = "2214C7CEFDE457CEE62140C3D4899B964E05236DA74E4243DFADF4AF29C382BB" },
   { name = "glisten", version = "8.0.0", build_tools = ["gleam"], requirements = ["gleam_erlang", "gleam_otp", "gleam_stdlib", "logging", "telemetry"], otp_app = "glisten", source = "hex", outer_checksum = "17B3CC2E5093662404DDCF7C837D1CA093E5C436CE5F8A532F8EA0D12B5B2172" },
   { name = "gramps", version = "3.0.2", build_tools = ["gleam"], requirements = ["gleam_crypto", "gleam_erlang", "gleam_http", "gleam_stdlib"], otp_app = "gramps", source = "hex", outer_checksum = "D213EEE41B467853E1FB9AAC204D2CB1AB301C84E8F7C1DF3307128221AB53BF" },
+  { name = "gtempo", version = "7.2.2", build_tools = ["gleam"], requirements = ["gleam_regexp", "gleam_stdlib", "gleam_time"], otp_app = "gtempo", source = "hex", outer_checksum = "51AACF841C5F936455973BAF7C03F1EEBF86EC0F0F8D9EBEE126CB02968D50AC" },
+  { name = "hackney", version = "1.24.1", build_tools = ["rebar3"], requirements = ["certifi", "idna", "metrics", "mimerl", "parse_trans", "ssl_verify_fun", "unicode_util_compat"], otp_app = "hackney", source = "hex", outer_checksum = "F4A7392A0B53D8BBC3EB855BDCC919CD677358E65B2AFD3840B5B3690C4C8A39" },
   { name = "houdini", version = "1.1.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "houdini", source = "hex", outer_checksum = "5BA517E5179F132F0471CB314F27FE210A10407387DA1EA4F6FD084F74469FC2" },
   { name = "hpack_erl", version = "0.3.0", build_tools = ["rebar3"], requirements = [], otp_app = "hpack", source = "hex", outer_checksum = "D6137D7079169D8C485C6962DFE261AF5B9EF60FBC557344511C1E65E3D95FB0" },
   { name = "hpax", version = "1.0.3", build_tools = ["mix"], requirements = [], otp_app = "hpax", source = "hex", outer_checksum = "8EAB6E1CFA8D5918C2CE4BA43588E894AF35DBD8E91E6E55C817BCA5847DF34A" },
+  { name = "idna", version = "6.1.1", build_tools = ["rebar3"], requirements = ["unicode_util_compat"], otp_app = "idna", source = "hex", outer_checksum = "92376EB7894412ED19AC475E4A86F7B413C1B9FBB5BD16DCCD57934157944CEA" },
   { name = "jason", version = "1.4.4", build_tools = ["mix"], requirements = ["decimal"], otp_app = "jason", source = "hex", outer_checksum = "C5EB0CAB91F094599F94D55BC63409236A8EC69A21A67814529E8D5F6CC90B3B" },
   { name = "logging", version = "1.3.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "logging", source = "hex", outer_checksum = "1098FBF10B54B44C2C7FDF0B01C1253CAFACDACABEFB4B0D027803246753E06D" },
   { name = "lustre", version = "5.2.1", build_tools = ["gleam"], requirements = ["gleam_erlang", "gleam_json", "gleam_otp", "gleam_stdlib", "houdini"], otp_app = "lustre", source = "hex", outer_checksum = "DCD121F8E6B7E179B27D9A8AEB6C828D8380E26DF2E16D078511EDAD1CA9F2A7" },
   { name = "marceau", version = "1.3.0", build_tools = ["gleam"], requirements = [], otp_app = "marceau", source = "hex", outer_checksum = "2D1C27504BEF45005F5DFB18591F8610FB4BFA91744878210BDC464412EC44E9" },
+  { name = "metrics", version = "1.0.1", build_tools = ["rebar3"], requirements = [], otp_app = "metrics", source = "hex", outer_checksum = "69B09ADDDC4F74A40716AE54D140F93BEB0FB8978D8636EADED0C31B6F099F16" },
   { name = "mime", version = "2.0.7", build_tools = ["mix"], requirements = [], otp_app = "mime", source = "hex", outer_checksum = "6171188E399EE16023FFC5B76CE445EB6D9672E2E241D2DF6050F3C771E80CCD" },
+  { name = "mimerl", version = "1.4.0", build_tools = ["rebar3"], requirements = [], otp_app = "mimerl", source = "hex", outer_checksum = "13AF15F9F68C65884ECCA3A3891D50A7B57D82152792F3E19D88650AA126B144" },
   { name = "mint", version = "1.7.1", build_tools = ["mix"], requirements = ["castore", "hpax"], otp_app = "mint", source = "hex", outer_checksum = "FCEBA0A4D0F24301DDEE3024AE116DF1C3F4BB7A563A731F45FDFEB9D39A231B" },
   { name = "mist", version = "5.0.2", build_tools = ["gleam"], requirements = ["gleam_erlang", "gleam_http", "gleam_otp", "gleam_stdlib", "gleam_yielder", "glisten", "gramps", "hpack_erl", "logging"], otp_app = "mist", source = "hex", outer_checksum = "0716CE491EA13E1AA1EFEC4B427593F8EB2B953B6EBDEBE41F15BE3D06A22918" },
   { name = "nimble_options", version = "1.1.1", build_tools = ["mix"], requirements = [], otp_app = "nimble_options", source = "hex", outer_checksum = "821B2470CA9442C4B6984882FE9BB0389371B8DDEC4D45A9504F00A66F650B44" },
   { name = "nimble_pool", version = "1.1.0", build_tools = ["mix"], requirements = [], otp_app = "nimble_pool", source = "hex", outer_checksum = "AF2E4E6B34197DB81F7AAD230C1118EAC993ACC0DAE6BC83BAC0126D4AE0813A" },
+  { name = "parse_trans", version = "3.4.1", build_tools = ["rebar3"], requirements = [], otp_app = "parse_trans", source = "hex", outer_checksum = "620A406CE75DADA827B82E453C19CF06776BE266F5A67CFF34E1EF2CBB60E49A" },
   { name = "platform", version = "1.0.0", build_tools = ["gleam"], requirements = [], otp_app = "platform", source = "hex", outer_checksum = "8339420A95AD89AAC0F82F4C3DB8DD401041742D6C3F46132A8739F6AEB75391" },
   { name = "req", version = "0.5.15", build_tools = ["mix"], requirements = ["brotli", "ezstd", "finch", "jason", "mime", "nimble_csv", "plug"], otp_app = "req", source = "hex", outer_checksum = "A6513A35FAD65467893CED9785457E91693352C70B58BBC045B47E5EB2EF0C53" },
   { name = "simplifile", version = "2.3.0", build_tools = ["gleam"], requirements = ["filepath", "gleam_stdlib"], otp_app = "simplifile", source = "hex", outer_checksum = "0A868DAC6063D9E983477981839810DC2E553285AB4588B87E3E9C96A7FB4CB4" },
   { name = "snag", version = "1.1.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "snag", source = "hex", outer_checksum = "7E9F06390040EB5FAB392CE642771484136F2EC103A92AE11BA898C8167E6E17" },
+  { name = "ssl_verify_fun", version = "1.1.7", build_tools = ["mix", "rebar3", "make"], requirements = [], otp_app = "ssl_verify_fun", source = "hex", outer_checksum = "FE4C190E8F37401D30167C8C405EDA19469F34577987C76DDE613E838BBC67F8" },
   { name = "telemetry", version = "1.3.0", build_tools = ["rebar3"], requirements = [], otp_app = "telemetry", source = "hex", outer_checksum = "7015FC8919DBE63764F4B4B87A95B7C0996BD539E0D499BE6EC9D7F3875B79E6" },
+  { name = "unicode_util_compat", version = "0.7.1", build_tools = ["rebar3"], requirements = [], otp_app = "unicode_util_compat", source = "hex", outer_checksum = "B3A917854CE3AE233619744AD1E0102E05673136776FB2FA76234F3E03B23642" },
   { name = "vix", version = "0.35.0", build_tools = ["mix", "make"], requirements = ["cc_precompiler", "elixir_make", "kino"], otp_app = "vix", source = "hex", outer_checksum = "A3E80067A89D0631B6CF2B93594E03C1B303A2C7CDDBBDD28040750D521984E5" },
   { name = "wisp", version = "1.8.0", build_tools = ["gleam"], requirements = ["directories", "exception", "gleam_crypto", "gleam_erlang", "gleam_http", "gleam_json", "gleam_stdlib", "houdini", "logging", "marceau", "mist", "simplifile"], otp_app = "wisp", source = "hex", outer_checksum = "0FE9049AFFB7C8D5FC0B154EEE2704806F4D51B97F44925D69349B3F4F192957" },
 ]
@@ -43,11 +59,14 @@ packages = [
 [requirements]
 gleam_crypto = { version = ">= 1.5.1 and < 2.0.0" }
 gleam_erlang = { version = ">= 1.2.0 and < 2.0.0" }
+gleam_hackney = { version = ">= 1.3.1 and < 2.0.0" }
 gleam_http = { version = ">= 4.1.0 and < 5.0.0" }
 gleam_json = { version = ">= 3.0.2 and < 4.0.0" }
 gleam_otp = { version = ">= 1.0.0 and < 2.0.0" }
 gleam_stdlib = { version = ">= 0.44.0 and < 2.0.0" }
+gleamql = { version = ">= 0.4.0 and < 1.0.0" }
 gleeunit = { version = ">= 1.0.0 and < 2.0.0" }
+gtempo = { version = ">= 7.2.2 and < 8.0.0" }
 lustre = { version = ">= 5.2.1 and < 6.0.0" }
 marceau = { version = ">= 1.3.0 and < 2.0.0" }
 mist = { version = ">= 5.0.2 and < 6.0.0" }

--- a/src/delayed.gleam
+++ b/src/delayed.gleam
@@ -6,6 +6,7 @@
 
 import entur_client
 import gleam/erlang/process
+import gleam/io
 import gleam/option
 import gleam/otp/actor
 
@@ -35,7 +36,9 @@ pub fn is_delayed(subject: process.Subject(DelayMessage)) -> Bool {
 }
 
 fn scheduler(subject: process.Subject(DelayMessage)) {
+  io.println("Updating")
   update(subject)
+  io.println("Updated - Waiting until next schedule")
   process.sleep(wait_time_ms)
   scheduler(subject)
 }

--- a/src/delayed.gleam
+++ b/src/delayed.gleam
@@ -1,0 +1,69 @@
+//// The purpose of this file is to hold data related to whether there are any current
+//// delays for Sørlandsbanen. We update only once every 5 minutes to avoid hitting the
+//// entur API any more than we need to.
+//// 
+//// Right now we will only hold a boolean, but in the future we might hold more data.
+
+import entur_client
+import gleam/erlang/process
+import gleam/option
+import gleam/otp/actor
+
+// 5 minutes in ms
+const wait_time_ms = 300_000
+
+// Starts a very simple scheduled process that kics inn every 5 minutes
+pub fn start() -> Result(
+  actor.Started(process.Subject(DelayMessage)),
+  actor.StartError,
+) {
+  let start_result =
+    actor.new(State(False))
+    |> actor.on_message(handle_message)
+    |> actor.start()
+  case start_result {
+    Ok(result) -> {
+      process.spawn(fn() { scheduler(result.data) })
+      start_result
+    }
+    Error(_) -> start_result
+  }
+}
+
+pub fn is_delayed(subject: process.Subject(DelayMessage)) -> Bool {
+  process.call(subject, 100, fn(reply_to) { GetState(reply_to) })
+}
+
+fn scheduler(subject: process.Subject(DelayMessage)) {
+  update(subject)
+  process.sleep(wait_time_ms)
+  scheduler(subject)
+}
+
+fn update(subject: process.Subject(DelayMessage)) {
+  let has_delays = case entur_client.check_for_dealays() {
+    option.Some(result) -> result
+    //Defaulting to False for now.
+    option.None -> False
+  }
+  process.send(subject, SetState(State(has_delays)))
+}
+
+pub type State {
+  State(has_delay: Bool)
+}
+
+pub type DelayMessage {
+  SetState(State)
+  GetState(process.Subject(Bool))
+}
+
+fn handle_message(state: State, message: DelayMessage) {
+  case message {
+    SetState(state) -> actor.continue(state)
+    GetState(reply_to) -> {
+      process.send(reply_to, state.has_delay)
+      actor.continue(state)
+    }
+  }
+}

--- a/src/delayed.gleam
+++ b/src/delayed.gleam
@@ -6,7 +6,6 @@
 
 import entur_client
 import gleam/erlang/process
-import gleam/io
 import gleam/option
 import gleam/otp/actor
 
@@ -36,9 +35,7 @@ pub fn is_delayed(subject: process.Subject(DelayMessage)) -> Bool {
 }
 
 fn scheduler(subject: process.Subject(DelayMessage)) {
-  io.println("Updating")
   update(subject)
-  io.println("Updated - Waiting until next schedule")
   process.sleep(wait_time_ms)
   scheduler(subject)
 }

--- a/src/entur_client.gleam
+++ b/src/entur_client.gleam
@@ -1,0 +1,212 @@
+import gleam/dynamic/decode
+import gleam/hackney
+import gleam/int
+import gleam/list
+import gleam/option
+import gleam/result
+import gleam/string
+import gleamql
+import tempo.{type Date, ISO8601Date, ISO8601Seconds}
+import tempo/date
+import tempo/datetime
+import tempo/duration
+import tempo/error
+
+pub fn check_for_dealays() -> option.Option(Bool) {
+  let query = query(date.current_local())
+  let result: Result(option.Option(Data), gleamql.GraphQLError) =
+    gleamql.new()
+    |> gleamql.set_query(query)
+    |> gleamql.set_host("https://api.entur.io/journey-planner/v3")
+    |> gleamql.set_path("/graphql")
+    |> gleamql.set_default_content_type_header()
+    |> gleamql.set_decoder(data_decoder())
+    |> gleamql.send(hackney.send)
+  case result {
+    Ok(data_option) ->
+      case data_option {
+        option.Some(data) -> option.Some(has_delays(data))
+        option.None -> option.None
+      }
+    Error(_) -> option.None
+  }
+}
+
+fn has_delays(data: Data) -> Bool {
+  let lines_delayed =
+    data.lines
+    |> list.filter(fn(line) {
+      False == line.service_journeys |> list.is_empty()
+    })
+    |> list.filter(fn(line) {
+      any_service_journeys_delayed(line.service_journeys)
+    })
+    |> list.length()
+  lines_delayed > 0
+}
+
+fn any_service_journeys_delayed(service_journeys: List(ServiceJourney)) -> Bool {
+  let delayed_journeys =
+    service_journeys
+    |> list.filter(fn(joruney) {
+      any_estimated_calls_delayed(joruney.estimated_calls)
+    })
+    |> list.length()
+  delayed_journeys > 0
+}
+
+fn any_estimated_calls_delayed(estimated_calls: List(EstimatedCall)) -> Bool {
+  let delayed_estimated_calls =
+    estimated_calls
+    |> list.filter(fn(estimated_call) { estimated_call.realtime })
+    |> list.filter(fn(estimated_call) {
+      estimated_call.actual_arrival_time |> string.is_empty()
+    })
+    |> list.filter(fn(estimated_call) {
+      is_estimated_call_delayed(estimated_call)
+    })
+    |> list.length()
+  delayed_estimated_calls > 0
+}
+
+fn is_estimated_call_delayed(estimated_call: EstimatedCall) -> Bool {
+  case
+    is_delayed(
+      estimated_call.expected_arrival_time,
+      estimated_call.aimed_arrival_time,
+    )
+  {
+    Ok(is_delayed) -> is_delayed
+    //Default to false in case of error
+    Error(_) -> False
+  }
+}
+
+fn is_delayed(
+  expected_arrival: String,
+  aimed_arrival: String,
+) -> Result(Bool, error.DateTimeParseError) {
+  use expected_arrival_datetime <- result.try(datetime.parse(
+    expected_arrival,
+    in: ISO8601Seconds,
+  ))
+  use aimed_arrival_datetime <- result.try(datetime.parse(
+    aimed_arrival,
+    in: ISO8601Seconds,
+  ))
+  let minute_difference =
+    datetime.difference(aimed_arrival_datetime, expected_arrival_datetime)
+    |> duration.as_minutes()
+    |> int.absolute_value()
+
+  // We allow for a 15 minute wiggleroom before we call something delayed.
+  Ok(minute_difference > 15)
+}
+
+fn query(date: Date) -> String {
+  "{
+  lines(publicCode: \"F5\") {
+    id
+    serviceJourneys {
+      estimatedCalls(date: \"" <> date.format(date, in: ISO8601Date) <> "\") {
+        aimedArrivalTime
+        cancellation
+        date
+        expectedArrivalTime
+        realtime
+        realtimeState
+        actualArrivalTime
+      }
+    }
+  }
+}
+"
+}
+
+pub fn data_decoder() -> decode.Decoder(Data) {
+  let decoder = {
+    use lines <- decode.field("lines", decode.list(line_decoder()))
+    decode.success(Data(lines))
+  }
+  decoder
+}
+
+fn line_decoder() -> decode.Decoder(Line) {
+  let decoder = {
+    use id <- decode.field("id", decode.string)
+    use service_journeys <- decode.field(
+      "serviceJourneys",
+      decode.list(service_journey_decoder()),
+    )
+    decode.success(Line(id, service_journeys))
+  }
+  decoder
+}
+
+fn service_journey_decoder() -> decode.Decoder(ServiceJourney) {
+  let decoder = {
+    use id <- decode.field("id", decode.int)
+    use estimated_calls <- decode.field(
+      "estimatedCalls",
+      decode.list(estimated_call_decoder()),
+    )
+    decode.success(ServiceJourney(id, estimated_calls))
+  }
+  decoder
+}
+
+fn estimated_call_decoder() -> decode.Decoder(EstimatedCall) {
+  let decoder = {
+    use aimed_arrival_time <- decode.field("aimedArrivalTime", decode.string)
+    use cancellation <- decode.field("cancellation", decode.bool)
+    use date <- decode.field("date", decode.string)
+    use expected_arrival_time <- decode.field(
+      "expectedArrivalTime",
+      decode.string,
+    )
+    use realtime <- decode.field("realtime", decode.bool)
+    use realtime_state <- decode.field("realtimeState", decode.string)
+    use actual_arrival_time <- decode.optional_field(
+      "actualArrivalTime",
+      "",
+      decode.string,
+    )
+    decode.success(EstimatedCall(
+      aimed_arrival_time,
+      cancellation,
+      date,
+      expected_arrival_time,
+      realtime,
+      realtime_state,
+      actual_arrival_time,
+    ))
+  }
+  decoder
+}
+
+pub type Data {
+  Data(lines: List(Line))
+}
+
+pub type Line {
+  Line(id: String, service_journeys: List(ServiceJourney))
+}
+
+pub type ServiceJourney {
+  ServiceJourney(id: Int, estimated_calls: List(EstimatedCall))
+}
+
+pub type EstimatedCall {
+  EstimatedCall(
+    aimed_arrival_time: String,
+    // ISO 8601 string (or DateTime type if parsed)
+    cancellation: Bool,
+    date: String,
+    // just the YYYY-MM-DD part
+    expected_arrival_time: String,
+    realtime: Bool,
+    realtime_state: String,
+    actual_arrival_time: String,
+    // null becomes Option type
+  )
+}

--- a/src/entur_decoder.gleam
+++ b/src/entur_decoder.gleam
@@ -1,0 +1,85 @@
+import gleam/dynamic/decode
+
+pub fn data_decoder() -> decode.Decoder(Data) {
+  let decoder = {
+    use lines <- decode.subfield(["data", "lines"], decode.list(line_decoder()))
+    decode.success(Data(lines))
+  }
+  decoder
+}
+
+fn line_decoder() -> decode.Decoder(Line) {
+  let decoder = {
+    use id <- decode.field("id", decode.string)
+    use service_journeys <- decode.field(
+      "serviceJourneys",
+      decode.list(service_journey_decoder()),
+    )
+    decode.success(Line(id, service_journeys))
+  }
+  decoder
+}
+
+fn service_journey_decoder() -> decode.Decoder(ServiceJourney) {
+  let decoder = {
+    use estimated_calls <- decode.field(
+      "estimatedCalls",
+      decode.list(estimated_call_decoder()),
+    )
+    decode.success(ServiceJourney(estimated_calls))
+  }
+  decoder
+}
+
+fn estimated_call_decoder() -> decode.Decoder(EstimatedCall) {
+  let decoder = {
+    use aimed_arrival_time <- decode.field("aimedArrivalTime", decode.string)
+    use cancellation <- decode.field("cancellation", decode.bool)
+    use date <- decode.field("date", decode.string)
+    use expected_arrival_time <- decode.field(
+      "expectedArrivalTime",
+      decode.string,
+    )
+    use realtime <- decode.field("realtime", decode.bool)
+    use realtime_state <- decode.field("realtimeState", decode.string)
+    use actual_arrival_time <- decode.optional_field(
+      "actualArrivalTime",
+      "",
+      decode.string,
+    )
+    decode.success(EstimatedCall(
+      aimed_arrival_time,
+      cancellation,
+      date,
+      expected_arrival_time,
+      realtime,
+      realtime_state,
+      actual_arrival_time,
+    ))
+  }
+  decoder
+}
+
+pub type Data {
+  Data(lines: List(Line))
+}
+
+pub type Line {
+  Line(id: String, service_journeys: List(ServiceJourney))
+}
+
+pub type ServiceJourney {
+  ServiceJourney(estimated_calls: List(EstimatedCall))
+}
+
+pub type EstimatedCall {
+  EstimatedCall(
+    aimed_arrival_time: String,
+    cancellation: Bool,
+    date: String,
+    expected_arrival_time: String,
+    realtime: Bool,
+    realtime_state: String,
+    actual_arrival_time: String,
+  )
+}

--- a/src/surtoget.gleam
+++ b/src/surtoget.gleam
@@ -1,4 +1,5 @@
 import about
+import delayed
 import faq
 import gleam/bytes_tree
 import gleam/erlang/process
@@ -23,12 +24,21 @@ import wisp.{type Request, type Response}
 import wisp/internal
 import wisp/wisp_mist
 
+pub type Context {
+  Context(
+    image_cache_subject: process.Subject(image_cache.ImageCacheMessage),
+    delayed_subject: process.Subject(delayed.DelayMessage),
+  )
+}
+
 pub fn main() -> Nil {
   let secret_key_base = wisp.random_string(64)
   wisp.configure_logger()
   let assert Ok(cache) = image_cache.start()
+  let assert Ok(delayed) = delayed.start()
+  let ctx = Context(cache.data, delayed.data)
   let assert Ok(_) =
-    wisp_mist.handler(handle_request(_, cache.data), secret_key_base)
+    wisp_mist.handler(handle_request(_, ctx), secret_key_base)
     |> mist.new()
     |> mist.bind("0.0.0.0")
     |> mist.port(8000)
@@ -37,20 +47,14 @@ pub fn main() -> Nil {
   process.sleep_forever()
 }
 
-pub fn handle_request(
-  req: Request,
-  image_cache: process.Subject(image_cache.ImageCacheMessage),
-) -> Response {
+pub fn handle_request(req: Request, ctx: Context) -> Response {
   use <- wisp.serve_static(req, under: "/static", from: "priv/static")
   use <- wisp.serve_static(req, under: "/css", from: "priv/css")
   use <- wisp.serve_static(req, under: "/javascript", from: "priv/javascript")
-  route_request(req, image_cache)
+  route_request(req, ctx)
 }
 
-fn route_request(
-  req: Request,
-  image_cache: process.Subject(image_cache.ImageCacheMessage),
-) -> Response {
+fn route_request(req: Request, ctx: Context) -> Response {
   case wisp.path_segments(req) {
     [] | ["home"] | ["index"] -> render_page(main_content())
     ["om-surtoget"] -> render_page(about.render())
@@ -59,7 +63,7 @@ fn route_request(
     ["favicon.ico"] -> get_favicon(req)
     ["news"] -> news.get_news_articles() |> news.render() |> render_page()
     ["news", "images", image_id] ->
-      handle_news_image_request(image_id, req, image_cache)
+      handle_news_image_request(image_id, req, ctx.image_cache_subject)
     _ -> wisp.not_found()
   }
 }

--- a/src/surtoget.gleam
+++ b/src/surtoget.gleam
@@ -56,7 +56,7 @@ pub fn handle_request(req: Request, ctx: Context) -> Response {
 
 fn route_request(req: Request, ctx: Context) -> Response {
   case wisp.path_segments(req) {
-    [] | ["home"] | ["index"] -> render_page(main_content())
+    [] | ["home"] | ["index"] -> render_page(main_content(ctx.delayed_subject))
     ["om-surtoget"] -> render_page(about.render())
     ["faq"] -> render_page(faq.render())
     ["health"] -> wisp.ok()
@@ -280,17 +280,51 @@ fn li_nav_item(href_val: String, text_val: String) -> Element(msg) {
   ])
 }
 
-fn main_content() -> Element(msg) {
+fn main_content(
+  delayed_subject: process.Subject(delayed.DelayMessage),
+) -> Element(msg) {
   let articles = news.get_news_articles()
   let latest_news = list.take(articles, 3)
 
   html.main([class("my-10 space-y-16")], [
     blurb(),
+    render_delay_notice(delayed_subject),
     html.section([], [statistics.render()]),
     html.section([], [refund.render()]),
     html.section([], [stories.render()]),
     html.section([], [news.render(latest_news)]),
   ])
+}
+
+fn render_delay_notice(
+  delayed_subject: process.Subject(delayed.DelayMessage),
+) -> Element(msg) {
+  case delayed.is_delayed(delayed_subject) {
+    True ->
+      html.div([class("my-10 p-4 bg-yellow-100 rounded-lg shadow-md")], [
+        html.p(
+          [class("text-lg font-semibold text-yellow-800 flex items-center")],
+          [
+            html.span([class("relative flex h-3 w-3 mr-3")], [
+              html.span(
+                [
+                  class(
+                    "animate-ping absolute inline-flex h-full w-full rounded-full bg-red-400 opacity-75",
+                  ),
+                ],
+                [],
+              ),
+              html.span(
+                [class("relative inline-flex rounded-full h-3 w-3 bg-red-500")],
+                [],
+              ),
+            ]),
+            html.text("Akkurat nå: Sørlandsbanen er forsinket... Igjen 🙄"),
+          ],
+        ),
+      ])
+    False -> html.div([], [])
+  }
 }
 
 fn blurb() -> Element(msg) {

--- a/test.json
+++ b/test.json
@@ -1,0 +1,5610 @@
+{
+  "data": {
+    "lines": [
+      {
+        "id": "GOA:Line:50",
+        "serviceJourneys": [
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": [
+              {
+                "aimedArrivalTime": "2025-07-20T10:16:00+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T10:16:00+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-20T10:22:01+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T10:22:01+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-20T10:29:00+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T10:29:00+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-20T10:46:00+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T10:46:00+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-20T11:17:00+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T11:17:00+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-20T11:57:01+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T11:57:01+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-20T12:05:00+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T12:05:00+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-20T12:17:01+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T12:17:01+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-20T12:23:01+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T12:23:01+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-20T12:34:01+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T12:34:01+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-20T12:41:00+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T12:41:00+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-20T12:59:01+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T12:59:01+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-20T13:20:01+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T13:20:01+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-20T13:31:00+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T13:31:00+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-20T14:04:01+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T14:04:01+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-20T14:54:00+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T14:54:00+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-20T15:10:01+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T15:10:01+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-20T15:29:01+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T15:29:01+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-20T15:53:00+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T15:53:00+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-20T16:26:00+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T16:26:00+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-20T17:16:00+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T17:16:00+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              }
+            ]
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": [
+              {
+                "aimedArrivalTime": "2025-07-20T13:23:00+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T13:23:00+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-20T14:02:00+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T14:02:00+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-20T14:23:00+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T14:23:00+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              }
+            ]
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": [
+              {
+                "aimedArrivalTime": "2025-07-20T15:23:00+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T15:23:00+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-20T16:02:00+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T16:02:00+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-20T16:23:00+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T16:23:00+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              }
+            ]
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": [
+              {
+                "aimedArrivalTime": "2025-07-20T17:24:00+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T17:24:00+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-20T18:03:00+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T18:03:00+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-20T18:24:00+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T18:24:00+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              }
+            ]
+          },
+          {
+            "estimatedCalls": [
+              {
+                "aimedArrivalTime": "2025-07-20T19:23:00+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T19:23:00+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-20T20:02:00+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T20:02:00+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-20T20:23:00+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T20:23:00+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              }
+            ]
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": [
+              {
+                "aimedArrivalTime": "2025-07-20T21:31:00+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T21:31:00+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-20T22:10:00+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T22:10:00+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-20T22:31:00+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T22:31:00+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              }
+            ]
+          },
+          {
+            "estimatedCalls": [
+              {
+                "aimedArrivalTime": "2025-07-20T23:22:00+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T23:22:00+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-21T00:01:00+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-21T00:01:00+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-21T00:22:00+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-21T00:22:00+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              }
+            ]
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": [
+              {
+                "aimedArrivalTime": "2025-07-21T06:17:00+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-21T06:17:00+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-21T06:56:00+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-21T06:56:00+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-21T07:17:00+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-21T07:17:00+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              }
+            ]
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": [
+              {
+                "aimedArrivalTime": "2025-07-20T13:23:00+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T13:23:00+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-20T14:26:00+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T14:26:00+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-20T14:38:00+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T14:38:00+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              }
+            ]
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": [
+              {
+                "aimedArrivalTime": "2025-07-20T15:23:00+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T15:23:00+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-20T16:26:00+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T16:26:00+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-20T16:38:00+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T16:38:00+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              }
+            ]
+          },
+          {
+            "estimatedCalls": [
+              {
+                "aimedArrivalTime": "2025-07-20T17:24:00+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T17:24:00+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-20T18:27:00+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T18:27:00+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-20T18:39:00+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T18:39:00+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              }
+            ]
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": [
+              {
+                "aimedArrivalTime": "2025-07-20T19:23:00+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T19:23:00+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-20T20:26:00+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T20:26:00+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-20T20:38:00+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T20:38:00+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              }
+            ]
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": [
+              {
+                "aimedArrivalTime": "2025-07-20T21:31:00+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T21:31:00+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-20T22:34:00+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T22:34:00+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-20T22:46:00+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T22:46:00+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              }
+            ]
+          },
+          {
+            "estimatedCalls": [
+              {
+                "aimedArrivalTime": "2025-07-20T23:22:00+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T23:22:00+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-21T00:25:00+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-21T00:25:00+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-21T00:37:00+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-21T00:37:00+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              }
+            ]
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": [
+              {
+                "aimedArrivalTime": "2025-07-21T06:17:00+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-21T06:17:00+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-21T07:20:00+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-21T07:20:00+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-21T07:32:00+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-21T07:32:00+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              }
+            ]
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": [
+              {
+                "aimedArrivalTime": "2025-07-20T22:15:00+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T22:15:00+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-20T22:22:01+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T22:22:01+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-20T22:29:00+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T22:29:00+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-20T22:49:00+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T22:49:00+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-20T23:17:00+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T23:17:00+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-21T00:00:01+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-21T00:00:01+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-21T00:08:01+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-21T00:08:01+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-21T00:21:01+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-21T00:21:01+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-21T00:27:01+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-21T00:27:01+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-21T00:40:01+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-21T00:40:01+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-21T00:47:01+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-21T00:47:01+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-21T01:02:01+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-21T01:02:01+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-21T01:23:01+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-21T01:23:01+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-21T01:35:00+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-21T01:35:00+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-21T02:35:01+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-21T02:35:01+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-21T03:31:01+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-21T03:31:01+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-21T03:47:01+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-21T03:47:01+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-21T04:07:01+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-21T04:07:01+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-21T04:22:01+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-21T04:22:01+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-21T04:35:01+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-21T04:35:01+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-21T04:57:01+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-21T04:57:01+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-21T05:10:00+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-21T05:10:00+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-21T05:26:01+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-21T05:26:01+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-21T06:10:00+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-21T06:10:00+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              }
+            ]
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": [
+              {
+                "aimedArrivalTime": "2025-07-20T23:43:00+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T23:43:00+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-21T00:20:01+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-21T00:20:01+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-21T00:36:00+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-21T00:36:00+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-21T00:48:01+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-21T00:48:01+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-21T01:11:01+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-21T01:11:01+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-21T01:25:01+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-21T01:25:01+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-21T01:39:01+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-21T01:39:01+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-21T02:00:01+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-21T02:00:01+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-21T02:16:01+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-21T02:16:01+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-21T03:16:01+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-21T03:16:01+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-21T03:30:00+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-21T03:30:00+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-21T03:55:01+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-21T03:55:01+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-21T04:15:01+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-21T04:15:01+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-21T04:30:01+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-21T04:30:01+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-21T04:39:01+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-21T04:39:01+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-21T04:52:01+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-21T04:52:01+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-21T04:58:01+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-21T04:58:01+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-21T05:11:01+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-21T05:11:01+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-21T05:19:01+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-21T05:19:01+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-21T05:59:00+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-21T05:59:00+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-21T06:42:00+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-21T06:42:00+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-21T07:03:00+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-21T07:03:00+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-21T07:11:01+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-21T07:11:01+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-21T07:21:00+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-21T07:21:00+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              }
+            ]
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": [
+              {
+                "aimedArrivalTime": "2025-07-20T19:43:00+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T19:43:00+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-20T20:15:00+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T20:15:00+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-20T20:29:00+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T20:29:00+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-20T20:41:01+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T20:41:01+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-20T21:00:01+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T21:00:01+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-20T21:12:01+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T21:12:01+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-20T21:25:01+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T21:25:01+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-20T21:42:01+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T21:42:01+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-20T21:56:00+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T21:56:00+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-20T23:10:01+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T23:10:01+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-20T23:34:00+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T23:34:00+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              }
+            ]
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": [
+              {
+                "aimedArrivalTime": "2025-07-20T22:47:00+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T22:47:00+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-20T23:25:00+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T23:25:00+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-20T23:39:00+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T23:39:00+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-20T23:51:01+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T23:51:01+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-21T00:11:01+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-21T00:11:01+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-21T00:23:01+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-21T00:23:01+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-21T00:36:01+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-21T00:36:01+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-21T00:53:00+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-21T00:53:00+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-21T01:10:00+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-21T01:10:00+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-21T01:56:01+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-21T01:56:01+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-21T02:08:00+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-21T02:08:00+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              }
+            ]
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": [
+              {
+                "aimedArrivalTime": "2025-07-20T08:47:00+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T08:47:00+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-20T08:53:01+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T08:53:01+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-20T09:00:00+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T09:00:00+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-20T09:16:00+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T09:16:00+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-20T09:42:00+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T09:42:00+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-20T10:18:01+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T10:18:01+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-20T10:25:00+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T10:25:00+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-20T10:36:01+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T10:36:01+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-20T10:42:01+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T10:42:01+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-20T10:53:01+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T10:53:01+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-20T11:00:01+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T11:00:01+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-20T11:13:01+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T11:13:01+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-20T11:32:01+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T11:32:01+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-20T11:43:00+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T11:43:00+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-20T12:07:01+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T12:07:01+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-20T12:52:00+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T12:52:00+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-20T13:08:01+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T13:08:01+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-20T13:25:00+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T13:25:00+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-20T13:40:01+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T13:40:01+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-20T13:52:00+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T13:52:00+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-20T14:14:01+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T14:14:01+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-20T14:25:00+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T14:25:00+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-20T14:40:00+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T14:40:00+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-20T15:14:00+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T15:14:00+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              }
+            ]
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": [
+              {
+                "aimedArrivalTime": "2025-07-20T16:04:00+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T16:04:00+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-20T16:10:01+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T16:10:01+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-20T16:17:00+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T16:17:00+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-20T16:36:00+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T16:36:00+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-20T17:16:00+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T17:16:00+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-20T18:03:01+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T18:03:01+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-20T18:10:00+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T18:10:00+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-20T18:21:01+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T18:21:01+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-20T18:27:01+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T18:27:01+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-20T18:38:01+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T18:38:01+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-20T18:54:01+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T18:54:01+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-20T19:07:01+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T19:07:01+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-20T19:25:01+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T19:25:01+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-20T19:36:00+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T19:36:00+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-20T20:04:01+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T20:04:01+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-20T20:50:00+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T20:50:00+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-20T21:07:01+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T21:07:01+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-20T21:25:01+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T21:25:01+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-20T21:49:01+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T21:49:01+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-20T22:10:01+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T22:10:01+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-20T22:21:00+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T22:21:00+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-20T22:36:00+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T22:36:00+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-20T23:15:00+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T23:15:00+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              }
+            ]
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": [
+              {
+                "aimedArrivalTime": "2025-07-20T09:54:00+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T09:54:00+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-20T10:06:01+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T10:06:01+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-20T10:51:00+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T10:51:00+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-20T11:07:01+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T11:07:01+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-20T11:25:01+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T11:25:01+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-20T11:38:01+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T11:38:01+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-20T11:51:00+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T11:51:00+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-20T12:24:00+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T12:24:00+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-20T12:40:00+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T12:40:00+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-20T13:15:00+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T13:15:00+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              }
+            ]
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": [
+              {
+                "aimedArrivalTime": "2025-07-20T08:36:00+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T08:17:02+02:00",
+                "realtime": true,
+                "realtimeState": "updated",
+                "actualArrivalTime": "2025-07-20T08:17:02+02:00"
+              },
+              {
+                "aimedArrivalTime": "2025-07-20T09:08:00+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T09:08:18+02:00",
+                "realtime": true,
+                "realtimeState": "updated",
+                "actualArrivalTime": "2025-07-20T09:08:18+02:00"
+              },
+              {
+                "aimedArrivalTime": "2025-07-20T09:22:00+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T09:22:09+02:00",
+                "realtime": true,
+                "realtimeState": "updated",
+                "actualArrivalTime": "2025-07-20T09:22:09+02:00"
+              },
+              {
+                "aimedArrivalTime": "2025-07-20T09:52:00+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T09:52:53+02:00",
+                "realtime": true,
+                "realtimeState": "updated",
+                "actualArrivalTime": "2025-07-20T09:52:53+02:00"
+              },
+              {
+                "aimedArrivalTime": "2025-07-20T10:05:01+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T10:04:07+02:00",
+                "realtime": true,
+                "realtimeState": "updated",
+                "actualArrivalTime": "2025-07-20T10:04:07+02:00"
+              },
+              {
+                "aimedArrivalTime": "2025-07-20T10:18:01+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T10:17:45+02:00",
+                "realtime": true,
+                "realtimeState": "updated",
+                "actualArrivalTime": "2025-07-20T10:17:45+02:00"
+              },
+              {
+                "aimedArrivalTime": "2025-07-20T10:35:01+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T10:36:13+02:00",
+                "realtime": true,
+                "realtimeState": "updated",
+                "actualArrivalTime": "2025-07-20T10:36:13+02:00"
+              },
+              {
+                "aimedArrivalTime": "2025-07-20T10:50:00+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T10:49:45+02:00",
+                "realtime": true,
+                "realtimeState": "updated",
+                "actualArrivalTime": "2025-07-20T10:49:45+02:00"
+              },
+              {
+                "aimedArrivalTime": "2025-07-20T11:38:01+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T11:40:46+02:00",
+                "realtime": true,
+                "realtimeState": "updated",
+                "actualArrivalTime": "2025-07-20T11:40:46+02:00"
+              },
+              {
+                "aimedArrivalTime": "2025-07-20T11:51:00+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T11:53:33+02:00",
+                "realtime": true,
+                "realtimeState": "updated",
+                "actualArrivalTime": "2025-07-20T11:53:33+02:00"
+              },
+              {
+                "aimedArrivalTime": "2025-07-20T12:08:01+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T12:13:10+02:00",
+                "realtime": true,
+                "realtimeState": "updated",
+                "actualArrivalTime": "2025-07-20T12:13:10+02:00"
+              },
+              {
+                "aimedArrivalTime": "2025-07-20T12:31:01+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T12:31:46+02:00",
+                "realtime": true,
+                "realtimeState": "updated",
+                "actualArrivalTime": "2025-07-20T12:31:46+02:00"
+              },
+              {
+                "aimedArrivalTime": "2025-07-20T12:44:01+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T12:45:36+02:00",
+                "realtime": true,
+                "realtimeState": "updated",
+                "actualArrivalTime": "2025-07-20T12:45:36+02:00"
+              },
+              {
+                "aimedArrivalTime": "2025-07-20T12:52:01+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T12:52:57+02:00",
+                "realtime": true,
+                "realtimeState": "updated",
+                "actualArrivalTime": "2025-07-20T12:52:57+02:00"
+              },
+              {
+                "aimedArrivalTime": "2025-07-20T13:07:01+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T13:07:24+02:00",
+                "realtime": true,
+                "realtimeState": "updated",
+                "actualArrivalTime": "2025-07-20T13:07:24+02:00"
+              },
+              {
+                "aimedArrivalTime": "2025-07-20T13:12:01+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T13:12:05+02:00",
+                "realtime": true,
+                "realtimeState": "updated",
+                "actualArrivalTime": "2025-07-20T13:12:05+02:00"
+              },
+              {
+                "aimedArrivalTime": "2025-07-20T13:24:00+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T13:24:21+02:00",
+                "realtime": true,
+                "realtimeState": "updated",
+                "actualArrivalTime": "2025-07-20T13:24:21+02:00"
+              },
+              {
+                "aimedArrivalTime": "2025-07-20T13:31:01+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T13:31:31+02:00",
+                "realtime": true,
+                "realtimeState": "updated",
+                "actualArrivalTime": "2025-07-20T13:31:31+02:00"
+              },
+              {
+                "aimedArrivalTime": "2025-07-20T14:05:00+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T14:10:26+02:00",
+                "realtime": true,
+                "realtimeState": "updated",
+                "actualArrivalTime": "2025-07-20T14:10:26+02:00"
+              },
+              {
+                "aimedArrivalTime": "2025-07-20T14:38:00+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T14:43:42+02:00",
+                "realtime": true,
+                "realtimeState": "updated",
+                "actualArrivalTime": "2025-07-20T14:43:42+02:00"
+              },
+              {
+                "aimedArrivalTime": "2025-07-20T14:50:00+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T15:59:22+02:00",
+                "realtime": true,
+                "realtimeState": "updated",
+                "actualArrivalTime": "2025-07-20T15:59:22+02:00"
+              },
+              {
+                "aimedArrivalTime": "2025-07-20T14:58:01+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T16:06:13+02:00",
+                "realtime": true,
+                "realtimeState": "updated",
+                "actualArrivalTime": "2025-07-20T16:06:13+02:00"
+              },
+              {
+                "aimedArrivalTime": "2025-07-20T15:05:00+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T16:12:57+02:00",
+                "realtime": true,
+                "realtimeState": "updated",
+                "actualArrivalTime": "2025-07-20T16:12:57+02:00"
+              }
+            ]
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": [
+              {
+                "aimedArrivalTime": "2025-07-20T07:00:00+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T07:00:00+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-20T08:11:00+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T08:11:00+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              }
+            ]
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": [
+              {
+                "aimedArrivalTime": "2025-07-20T11:00:00+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T11:00:00+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-20T12:11:00+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T12:11:00+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              }
+            ]
+          },
+          {
+            "estimatedCalls": [
+              {
+                "aimedArrivalTime": "2025-07-20T13:00:00+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T13:00:00+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-20T14:11:00+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T14:11:00+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              }
+            ]
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": [
+              {
+                "aimedArrivalTime": "2025-07-20T15:00:00+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T15:00:00+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-20T16:11:00+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T16:11:00+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              }
+            ]
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": [
+              {
+                "aimedArrivalTime": "2025-07-20T17:00:00+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T17:00:00+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-20T18:11:00+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T18:11:00+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              }
+            ]
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": [
+              {
+                "aimedArrivalTime": "2025-07-20T17:00:00+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T17:00:00+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-20T18:11:00+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T18:11:00+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              }
+            ]
+          },
+          {
+            "estimatedCalls": [
+              {
+                "aimedArrivalTime": "2025-07-20T22:00:00+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T22:00:00+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-20T23:11:00+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T23:11:00+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              }
+            ]
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": [
+              {
+                "aimedArrivalTime": "2025-07-20T16:36:00+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T15:47:14+02:00",
+                "realtime": true,
+                "realtimeState": "updated",
+                "actualArrivalTime": "2025-07-20T15:47:14+02:00"
+              },
+              {
+                "aimedArrivalTime": "2025-07-20T17:25:00+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T17:21:54+02:00",
+                "realtime": true,
+                "realtimeState": "updated",
+                "actualArrivalTime": "2025-07-20T17:21:54+02:00"
+              },
+              {
+                "aimedArrivalTime": "2025-07-20T17:36:01+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T17:36:19+02:00",
+                "realtime": true,
+                "realtimeState": "updated",
+                "actualArrivalTime": "2025-07-20T17:36:19+02:00"
+              },
+              {
+                "aimedArrivalTime": "2025-07-20T17:56:00+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T17:57:18+02:00",
+                "realtime": true,
+                "realtimeState": "updated",
+                "actualArrivalTime": "2025-07-20T17:57:18+02:00"
+              },
+              {
+                "aimedArrivalTime": "2025-07-20T18:08:01+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T18:10:01+02:00",
+                "realtime": true,
+                "realtimeState": "updated",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-20T18:21:01+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T18:22:07+02:00",
+                "realtime": true,
+                "realtimeState": "updated",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-20T18:38:01+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T18:38:23+02:00",
+                "realtime": true,
+                "realtimeState": "updated",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-20T18:52:00+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T18:52:00+02:00",
+                "realtime": true,
+                "realtimeState": "updated",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-20T19:38:01+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T19:38:01+02:00",
+                "realtime": true,
+                "realtimeState": "updated",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-20T19:51:00+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T19:51:00+02:00",
+                "realtime": true,
+                "realtimeState": "updated",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-20T20:07:01+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T20:07:01+02:00",
+                "realtime": true,
+                "realtimeState": "updated",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-20T20:25:01+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T20:25:01+02:00",
+                "realtime": true,
+                "realtimeState": "updated",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-20T20:38:01+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T20:38:01+02:00",
+                "realtime": true,
+                "realtimeState": "updated",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-20T20:46:00+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T20:46:00+02:00",
+                "realtime": true,
+                "realtimeState": "updated",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-20T21:00:01+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T21:00:01+02:00",
+                "realtime": true,
+                "realtimeState": "updated",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-20T21:06:01+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T21:06:01+02:00",
+                "realtime": true,
+                "realtimeState": "updated",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-20T21:20:00+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T21:20:00+02:00",
+                "realtime": true,
+                "realtimeState": "updated",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-20T21:27:01+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T21:27:01+02:00",
+                "realtime": true,
+                "realtimeState": "updated",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-20T22:08:00+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T22:08:00+02:00",
+                "realtime": true,
+                "realtimeState": "updated",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-20T22:38:00+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T22:38:00+02:00",
+                "realtime": true,
+                "realtimeState": "updated",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-20T23:00:00+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T23:00:00+02:00",
+                "realtime": true,
+                "realtimeState": "updated",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-20T23:07:01+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T23:07:01+02:00",
+                "realtime": true,
+                "realtimeState": "updated",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-20T23:14:00+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T23:14:00+02:00",
+                "realtime": true,
+                "realtimeState": "updated",
+                "actualArrivalTime": null
+              }
+            ]
+          },
+          {
+            "estimatedCalls": [
+              {
+                "aimedArrivalTime": "2025-07-20T15:16:00+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T15:16:00+02:00",
+                "realtime": true,
+                "realtimeState": "Added",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-20T15:37:00+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T15:37:00+02:00",
+                "realtime": true,
+                "realtimeState": "Added",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-20T16:19:00+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T16:19:00+02:00",
+                "realtime": true,
+                "realtimeState": "Added",
+                "actualArrivalTime": null
+              }
+            ]
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": [
+              {
+                "aimedArrivalTime": "2025-07-20T09:05:00+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T09:05:00+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-20T09:13:01+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T09:13:01+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-20T09:35:01+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T09:35:01+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-20T09:47:01+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T09:47:01+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-20T09:55:01+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T09:55:01+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-20T10:06:01+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T10:06:01+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-20T10:11:01+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T10:11:01+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-20T10:22:00+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T10:22:00+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-20T10:31:01+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T10:31:01+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-20T11:06:00+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T11:06:00+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-20T11:39:00+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T11:39:00+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-20T11:50:00+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T11:50:00+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-20T11:58:01+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T11:58:01+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-20T12:05:00+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T12:05:00+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              }
+            ]
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": [
+              {
+                "aimedArrivalTime": "2025-07-20T15:23:00+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T15:23:00+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-20T16:34:00+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T16:34:00+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              }
+            ]
+          },
+          {
+            "estimatedCalls": [
+              {
+                "aimedArrivalTime": "2025-07-20T17:24:00+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T17:24:00+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-20T18:35:00+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T18:35:00+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              }
+            ]
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": [
+              {
+                "aimedArrivalTime": "2025-07-20T19:23:00+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T19:23:00+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-20T20:34:00+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T20:34:00+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              }
+            ]
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": [
+              {
+                "aimedArrivalTime": "2025-07-20T21:31:00+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T21:31:00+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-20T22:42:00+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T22:42:00+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              }
+            ]
+          },
+          {
+            "estimatedCalls": [
+              {
+                "aimedArrivalTime": "2025-07-20T23:22:00+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T23:22:00+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-21T00:33:00+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-21T00:33:00+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              }
+            ]
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": [
+              {
+                "aimedArrivalTime": "2025-07-21T06:17:00+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-21T06:17:00+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-21T07:28:00+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-21T07:28:00+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              }
+            ]
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": [
+              {
+                "aimedArrivalTime": "2025-07-20T14:38:00+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T14:38:00+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-20T14:44:01+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T14:44:01+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-20T14:50:00+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T14:50:00+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-20T15:07:00+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T15:07:00+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-20T15:33:00+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T15:33:00+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-20T16:13:01+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T16:13:01+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-20T16:20:00+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T16:20:00+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-20T16:31:01+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T16:31:01+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-20T16:37:01+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T16:37:01+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-20T16:49:00+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T16:49:00+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-20T17:04:01+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T17:04:01+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-20T17:17:01+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T17:17:01+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-20T17:35:01+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T17:35:01+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-20T17:46:00+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T17:46:00+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-20T18:06:01+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T18:06:01+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-20T18:51:00+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T18:51:00+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-20T19:06:01+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T19:06:01+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-20T19:23:01+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T19:23:01+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-20T19:36:01+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T19:36:01+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-20T19:48:01+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T19:48:01+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-20T20:18:01+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T20:18:01+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-20T20:29:00+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T20:29:00+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-20T20:45:00+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T20:45:00+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-20T21:22:00+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T21:22:00+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              }
+            ]
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": [
+              {
+                "aimedArrivalTime": "2025-07-20T07:00:00+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T07:00:00+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-20T07:12:00+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T07:12:00+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-20T08:15:00+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T08:15:00+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              }
+            ]
+          },
+          {
+            "estimatedCalls": [
+              {
+                "aimedArrivalTime": "2025-07-20T11:00:00+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T11:00:00+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-20T11:12:00+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T11:12:00+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-20T12:15:00+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T12:15:00+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              }
+            ]
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": [
+              {
+                "aimedArrivalTime": "2025-07-20T13:00:00+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T13:00:00+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-20T13:12:00+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T13:12:00+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-20T14:15:00+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T14:15:00+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              }
+            ]
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": [
+              {
+                "aimedArrivalTime": "2025-07-20T15:00:00+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T15:00:00+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-20T15:12:00+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T15:12:00+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-20T16:15:00+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T16:15:00+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              }
+            ]
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": [
+              {
+                "aimedArrivalTime": "2025-07-20T17:00:00+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T17:00:00+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-20T17:12:00+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T17:12:00+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-20T18:15:00+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T18:15:00+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              }
+            ]
+          },
+          {
+            "estimatedCalls": [
+              {
+                "aimedArrivalTime": "2025-07-20T17:00:00+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T17:00:00+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-20T17:12:00+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T17:12:00+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-20T18:15:00+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T18:15:00+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              }
+            ]
+          },
+          {
+            "estimatedCalls": [
+              {
+                "aimedArrivalTime": "2025-07-20T21:00:00+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T21:00:00+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-20T21:12:00+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T21:12:00+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-20T22:15:00+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T22:15:00+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              }
+            ]
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": [
+              {
+                "aimedArrivalTime": "2025-07-20T22:00:00+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T22:00:00+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-20T22:12:00+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T22:12:00+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-20T23:15:00+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T23:15:00+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              }
+            ]
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": [
+              {
+                "aimedArrivalTime": "2025-07-20T07:16:00+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T07:16:00+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-20T07:41:00+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T07:41:00+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-20T08:25:00+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T08:25:00+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              }
+            ]
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": [
+              {
+                "aimedArrivalTime": "2025-07-20T11:16:00+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T11:16:00+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-20T11:41:00+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T11:41:00+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-20T12:25:00+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T12:25:00+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              }
+            ]
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": [
+              {
+                "aimedArrivalTime": "2025-07-20T13:16:00+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T13:16:00+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-20T13:41:00+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T13:41:00+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-20T14:25:00+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T14:25:00+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              }
+            ]
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": [
+              {
+                "aimedArrivalTime": "2025-07-20T15:16:00+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T15:16:00+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-20T15:41:00+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T15:41:00+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-20T16:25:00+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T16:25:00+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              }
+            ]
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": [
+              {
+                "aimedArrivalTime": "2025-07-20T17:16:00+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T17:16:00+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-20T17:41:00+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T17:41:00+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-20T18:25:00+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T18:25:00+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              }
+            ]
+          },
+          {
+            "estimatedCalls": [
+              {
+                "aimedArrivalTime": "2025-07-20T17:16:00+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T17:16:00+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-20T17:41:00+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T17:41:00+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-20T18:25:00+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T18:25:00+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              }
+            ]
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": [
+              {
+                "aimedArrivalTime": "2025-07-20T21:16:00+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T21:16:00+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-20T21:41:00+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T21:41:00+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-20T22:25:00+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T22:25:00+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              }
+            ]
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": [
+              {
+                "aimedArrivalTime": "2025-07-20T22:16:00+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T22:16:00+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-20T22:41:00+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T22:41:00+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-20T23:25:00+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T23:25:00+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              }
+            ]
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": [
+              {
+                "aimedArrivalTime": "2025-07-20T14:36:00+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T14:26:03+02:00",
+                "realtime": true,
+                "realtimeState": "updated",
+                "actualArrivalTime": "2025-07-20T14:26:03+02:00"
+              },
+              {
+                "aimedArrivalTime": "2025-07-20T15:12:00+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T15:16:14+02:00",
+                "realtime": true,
+                "realtimeState": "updated",
+                "actualArrivalTime": "2025-07-20T15:16:14+02:00"
+              },
+              {
+                "aimedArrivalTime": "2025-07-20T15:26:00+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T15:29:54+02:00",
+                "realtime": true,
+                "realtimeState": "updated",
+                "actualArrivalTime": "2025-07-20T15:29:54+02:00"
+              },
+              {
+                "aimedArrivalTime": "2025-07-20T15:36:01+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T15:42:15+02:00",
+                "realtime": true,
+                "realtimeState": "updated",
+                "actualArrivalTime": "2025-07-20T15:42:15+02:00"
+              },
+              {
+                "aimedArrivalTime": "2025-07-20T15:56:00+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T16:03:13+02:00",
+                "realtime": true,
+                "realtimeState": "updated",
+                "actualArrivalTime": "2025-07-20T16:03:13+02:00"
+              },
+              {
+                "aimedArrivalTime": "2025-07-20T16:08:01+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T16:17:01+02:00",
+                "realtime": true,
+                "realtimeState": "updated",
+                "actualArrivalTime": "2025-07-20T16:17:01+02:00"
+              },
+              {
+                "aimedArrivalTime": "2025-07-20T16:23:01+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T16:30:45+02:00",
+                "realtime": true,
+                "realtimeState": "updated",
+                "actualArrivalTime": "2025-07-20T16:30:45+02:00"
+              },
+              {
+                "aimedArrivalTime": "2025-07-20T16:40:01+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T16:49:54+02:00",
+                "realtime": true,
+                "realtimeState": "updated",
+                "actualArrivalTime": "2025-07-20T16:49:54+02:00"
+              },
+              {
+                "aimedArrivalTime": "2025-07-20T16:54:00+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T17:09:32+02:00",
+                "realtime": true,
+                "realtimeState": "updated",
+                "actualArrivalTime": "2025-07-20T17:09:32+02:00"
+              },
+              {
+                "aimedArrivalTime": "2025-07-20T17:40:01+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T17:57:50+02:00",
+                "realtime": true,
+                "realtimeState": "updated",
+                "actualArrivalTime": "2025-07-20T17:57:50+02:00"
+              },
+              {
+                "aimedArrivalTime": "2025-07-20T17:53:00+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T18:10:41+02:00",
+                "realtime": true,
+                "realtimeState": "updated",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-20T18:09:01+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T18:24:00+02:00",
+                "realtime": true,
+                "realtimeState": "updated",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-20T18:26:01+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T18:40:25+02:00",
+                "realtime": true,
+                "realtimeState": "updated",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-20T18:39:01+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T18:52:36+02:00",
+                "realtime": true,
+                "realtimeState": "updated",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-20T18:47:01+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T19:00:03+02:00",
+                "realtime": true,
+                "realtimeState": "updated",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-20T18:59:01+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T19:10:47+02:00",
+                "realtime": true,
+                "realtimeState": "updated",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-20T19:05:01+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T19:16:14+02:00",
+                "realtime": true,
+                "realtimeState": "updated",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-20T19:17:00+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T19:27:01+02:00",
+                "realtime": true,
+                "realtimeState": "updated",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-20T19:25:01+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T19:33:52+02:00",
+                "realtime": true,
+                "realtimeState": "updated",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-20T20:03:00+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T20:06:56+02:00",
+                "realtime": true,
+                "realtimeState": "updated",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-20T20:50:00+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T20:50:00+02:00",
+                "realtime": true,
+                "realtimeState": "updated",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-20T21:01:00+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T21:01:00+02:00",
+                "realtime": true,
+                "realtimeState": "updated",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-20T21:08:01+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T21:08:01+02:00",
+                "realtime": true,
+                "realtimeState": "updated",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-20T21:15:00+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T21:15:00+02:00",
+                "realtime": true,
+                "realtimeState": "updated",
+                "actualArrivalTime": null
+              }
+            ]
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": [
+              {
+                "aimedArrivalTime": "2025-07-20T12:47:00+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T12:47:00+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-20T12:53:01+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T12:53:01+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-20T13:00:00+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T13:00:00+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-20T13:16:00+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T13:16:00+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-20T13:41:00+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T13:41:00+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-20T14:22:01+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T14:22:01+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-20T14:29:00+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T14:29:00+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-20T14:40:01+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T14:40:01+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-20T14:45:01+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T14:45:01+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-20T14:56:01+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T14:56:01+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-20T15:03:01+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T15:03:01+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-20T15:16:01+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T15:16:01+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-20T15:34:01+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T15:34:01+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-20T15:45:00+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T15:45:00+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-20T16:08:01+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T16:08:01+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-20T16:53:00+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T16:53:00+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-20T17:08:01+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T17:08:01+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-20T17:26:01+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T17:26:01+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-20T17:39:01+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T17:39:01+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-20T17:51:00+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T17:51:00+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-20T18:14:01+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T18:14:01+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-20T18:25:00+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T18:25:00+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-20T18:40:00+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T18:40:00+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              },
+              {
+                "aimedArrivalTime": "2025-07-20T19:15:00+02:00",
+                "cancellation": false,
+                "date": "2025-07-20",
+                "expectedArrivalTime": "2025-07-20T19:15:00+02:00",
+                "realtime": false,
+                "realtimeState": "scheduled",
+                "actualArrivalTime": null
+              }
+            ]
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          },
+          {
+            "estimatedCalls": []
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/test/entur_decoder_test.gleam
+++ b/test/entur_decoder_test.gleam
@@ -1,0 +1,39 @@
+import entur_decoder.{Data, EstimatedCall, Line, ServiceJourney}
+import gleam/json
+import gleeunit/should
+
+pub fn when_data_exists_test() {
+  let json_string =
+    "{\"data\":{\"lines\":[{\"id\":\"GOA:Line:50\",\"serviceJourneys\":[{\"estimatedCalls\":[{\"aimedArrivalTime\":\"2025-07-21T12:36:00+02:00\",\"cancellation\":false,\"date\":\"2025-07-21\",\"expectedArrivalTime\":\"2025-07-21T12:36:00+02:00\",\"realtime\":false,\"realtimeState\":\"scheduled\"}]}]}]}}"
+
+  let result =
+    json.parse(from: json_string, using: entur_decoder.data_decoder())
+  let expected =
+    Ok(
+      Data([
+        Line("GOA:Line:50", [
+          ServiceJourney([
+            EstimatedCall(
+              "2025-07-21T12:36:00+02:00",
+              False,
+              "2025-07-21",
+              "2025-07-21T12:36:00+02:00",
+              False,
+              "scheduled",
+              "",
+            ),
+          ]),
+        ]),
+      ]),
+    )
+
+  should.equal(result, expected)
+}
+
+pub fn empty_estimated_calls_should_not_cause_errors_test() {
+  let json_string =
+    "{\"data\":{\"lines\":[{\"id\":\"GOA:Line:50\",\"serviceJourneys\":[{\"estimatedCalls\":[]}]}]}}"
+  let result =
+    json.parse(from: json_string, using: entur_decoder.data_decoder())
+  should.equal(result, Ok(Data([Line("GOA:Line:50", [ServiceJourney([])])])))
+}


### PR DESCRIPTION
### Description

- Implement delay detection by querying the Entur GraphQL API and comparing expected vs. aimed arrival times with a 15-minute threshold.
- Add comprehensive JSON decoders for Entur API response data structures to enable robust parsing.
- Refactor entur_client to use new decoders and update API configuration constants.
- Display a dynamic delay notice banner on the main page for Sørlandsbanen delays.
- Add and later remove debug logging in the scheduler for update visibility and cleaner output.
- Add tests to verify correctness of data decoding and handling of edge cases.