### PR TITLE
feat: update entur client and decoder for optional arrival times

### DIFF
--- a/src/entur_client.gleam
+++ b/src/entur_client.gleam
@@ -1,10 +1,10 @@
 import entur_decoder.{type Data, type EstimatedCall, type ServiceJourney}
 import gleam/hackney
 import gleam/int
+import gleam/io
 import gleam/list
 import gleam/option
 import gleam/result
-import gleam/string
 import gleamql
 import tempo.{type Date, ISO8601Date, ISO8601Seconds}
 import tempo/date
@@ -65,7 +65,7 @@ fn any_estimated_calls_delayed(estimated_calls: List(EstimatedCall)) -> Bool {
     estimated_calls
     |> list.filter(fn(estimated_call) { estimated_call.realtime })
     |> list.filter(fn(estimated_call) {
-      estimated_call.actual_arrival_time |> string.is_empty()
+      estimated_call.actual_arrival_time |> option.is_none()
     })
     |> list.filter(fn(estimated_call) {
       is_estimated_call_delayed(estimated_call)
@@ -105,7 +105,11 @@ fn is_delayed(
     |> int.absolute_value()
 
   // We allow for a 15 minute wiggleroom before we call something delayed.
-  Ok(minute_difference > 15)
+  case minute_difference > 5 {
+    True -> io.println("THE TRAIN IS DELAYED")
+    False -> io.println("The train is not delayed")
+  }
+  Ok(minute_difference > 5)
 }
 
 fn query(date: Date) -> String {

--- a/src/entur_decoder.gleam
+++ b/src/entur_decoder.gleam
@@ -1,8 +1,9 @@
 import gleam/dynamic/decode
+import gleam/option
 
 pub fn data_decoder() -> decode.Decoder(Data) {
   let decoder = {
-    use lines <- decode.subfield(["data", "lines"], decode.list(line_decoder()))
+    use lines <- decode.field("lines", decode.list(line_decoder()))
     decode.success(Data(lines))
   }
   decoder
@@ -44,8 +45,8 @@ fn estimated_call_decoder() -> decode.Decoder(EstimatedCall) {
     use realtime_state <- decode.field("realtimeState", decode.string)
     use actual_arrival_time <- decode.optional_field(
       "actualArrivalTime",
-      "",
-      decode.string,
+      option.None,
+      decode.optional(decode.string),
     )
     decode.success(EstimatedCall(
       aimed_arrival_time,
@@ -80,6 +81,6 @@ pub type EstimatedCall {
     expected_arrival_time: String,
     realtime: Bool,
     realtime_state: String,
-    actual_arrival_time: String,
+    actual_arrival_time: option.Option(String),
   )
 }

--- a/src/index.gleam
+++ b/src/index.gleam
@@ -9,15 +9,13 @@ import refund
 import statistics
 import stories
 
-pub fn render(
-  delayed_subject: process.Subject(delayed.DelayMessage),
-) -> Element(msg) {
+pub fn render() -> Element(msg) {
   let articles = news.get_news_articles()
   let latest_news = list.take(articles, 3)
 
   html.main([class("my-10 space-y-16")], [
     blurb(),
-    render_delay_notice(delayed_subject),
+    //render_delay_notice(delayed_subject),
     html.section([], [statistics.render()]),
     html.section([], [refund.render()]),
     html.section([], [stories.render()]),
@@ -25,6 +23,7 @@ pub fn render(
   ])
 }
 
+//TODO Temporary removed due to using the wrong API 🤷🏻‍♂️
 fn render_delay_notice(
   delayed_subject: process.Subject(delayed.DelayMessage),
 ) -> Element(msg) {

--- a/src/surtoget.gleam
+++ b/src/surtoget.gleam
@@ -26,7 +26,7 @@ import wisp/wisp_mist
 pub type Context {
   Context(
     image_cache_subject: process.Subject(image_cache.ImageCacheMessage),
-    delayed_subject: process.Subject(delayed.DelayMessage),
+    // delayed_subject: process.Subject(delayed.DelayMessage),
     // Some pages are fully static, so we might as well pre-render them on startup
     // just to avoid doing extra processing (despite it being pretty fast anyway)
     about_page: response.Response(wisp.Body),
@@ -39,11 +39,11 @@ pub fn main() -> Nil {
   let secret_key_base = wisp.random_string(64)
   wisp.configure_logger()
   let assert Ok(cache) = image_cache.start()
-  let assert Ok(delayed) = delayed.start()
+  //let assert Ok(delayed) = delayed.start()
   let ctx =
     Context(
       image_cache_subject: cache.data,
-      delayed_subject: delayed.data,
+      //delayed_subject: delayed.data,
       about_page: render_page(about.render()),
       faq_page: render_page(faq.render()),
       news_page: news.get_news_articles() |> news.render() |> render_page(),
@@ -67,7 +67,7 @@ pub fn handle_request(req: Request, ctx: Context) -> Response {
 
 fn route_request(req: Request, ctx: Context) -> Response {
   case wisp.path_segments(req) {
-    [] | ["home"] | ["index"] -> render_page(index.render(ctx.delayed_subject))
+    [] | ["home"] | ["index"] -> render_page(index.render())
     ["om-surtoget"] -> ctx.about_page
     ["faq"] -> ctx.faq_page
     ["health"] -> wisp.ok()

--- a/test/entur_decoder_test.gleam
+++ b/test/entur_decoder_test.gleam
@@ -1,10 +1,11 @@
 import entur_decoder.{Data, EstimatedCall, Line, ServiceJourney}
 import gleam/json
+import gleam/option
 import gleeunit/should
 
 pub fn when_data_exists_test() {
   let json_string =
-    "{\"data\":{\"lines\":[{\"id\":\"GOA:Line:50\",\"serviceJourneys\":[{\"estimatedCalls\":[{\"aimedArrivalTime\":\"2025-07-21T12:36:00+02:00\",\"cancellation\":false,\"date\":\"2025-07-21\",\"expectedArrivalTime\":\"2025-07-21T12:36:00+02:00\",\"realtime\":false,\"realtimeState\":\"scheduled\"}]}]}]}}"
+    "{\"lines\":[{\"id\":\"GOA:Line:50\",\"serviceJourneys\":[{\"estimatedCalls\":[{\"aimedArrivalTime\":\"2025-07-21T12:36:00+02:00\",\"cancellation\":false,\"date\":\"2025-07-21\",\"expectedArrivalTime\":\"2025-07-21T12:36:00+02:00\",\"realtime\":false,\"realtimeState\":\"scheduled\"}]}]}]}"
 
   let result =
     json.parse(from: json_string, using: entur_decoder.data_decoder())
@@ -20,7 +21,7 @@ pub fn when_data_exists_test() {
               "2025-07-21T12:36:00+02:00",
               False,
               "scheduled",
-              "",
+              option.None,
             ),
           ]),
         ]),
@@ -32,8 +33,97 @@ pub fn when_data_exists_test() {
 
 pub fn empty_estimated_calls_should_not_cause_errors_test() {
   let json_string =
-    "{\"data\":{\"lines\":[{\"id\":\"GOA:Line:50\",\"serviceJourneys\":[{\"estimatedCalls\":[]}]}]}}"
+    "{\"lines\":[{\"id\":\"GOA:Line:50\",\"serviceJourneys\":[{\"estimatedCalls\":[]}]}]}"
+
   let result =
     json.parse(from: json_string, using: entur_decoder.data_decoder())
+
   should.equal(result, Ok(Data([Line("GOA:Line:50", [ServiceJourney([])])])))
+}
+
+pub fn estimated_call_with_null_actual_arrival_time_test() {
+  let json_string =
+    "{\"lines\":[{\"id\":\"GOA:Line:50\",\"serviceJourneys\":[{\"estimatedCalls\":[{\"aimedArrivalTime\":\"2025-07-21T12:36:00+02:00\",\"cancellation\":false,\"date\":\"2025-07-21\",\"expectedArrivalTime\":\"2025-07-21T12:36:00+02:00\",\"realtime\":false,\"realtimeState\":\"scheduled\",\"actualArrivalTime\":null}]}]}]}"
+
+  let result =
+    json.parse(from: json_string, using: entur_decoder.data_decoder())
+
+  let expected =
+    Ok(
+      Data([
+        Line("GOA:Line:50", [
+          ServiceJourney([
+            EstimatedCall(
+              "2025-07-21T12:36:00+02:00",
+              False,
+              "2025-07-21",
+              "2025-07-21T12:36:00+02:00",
+              False,
+              "scheduled",
+              option.None,
+            ),
+          ]),
+        ]),
+      ]),
+    )
+
+  should.equal(result, expected)
+}
+
+pub fn early_morning_estimated_call_test() {
+  let json_string =
+    "{\"lines\":[{\"id\":\"GOA:Line:50\",\"serviceJourneys\":[{\"estimatedCalls\":[{\"aimedArrivalTime\":\"2025-07-21T07:16:00+02:00\",\"cancellation\":false,\"date\":\"2025-07-21\",\"expectedArrivalTime\":\"2025-07-21T07:16:00+02:00\",\"realtime\":false,\"realtimeState\":\"scheduled\",\"actualArrivalTime\":null}]}]}]}"
+
+  let result =
+    json.parse(from: json_string, using: entur_decoder.data_decoder())
+
+  let expected =
+    Ok(
+      Data([
+        Line("GOA:Line:50", [
+          ServiceJourney([
+            EstimatedCall(
+              "2025-07-21T07:16:00+02:00",
+              False,
+              "2025-07-21",
+              "2025-07-21T07:16:00+02:00",
+              False,
+              "scheduled",
+              option.None,
+            ),
+          ]),
+        ]),
+      ]),
+    )
+
+  should.equal(result, expected)
+}
+
+pub fn estimated_call_with_realtime_and_actual_arrival_time_test() {
+  let json_string =
+    "{\"lines\":[{\"id\":\"GOA:Line:50\",\"serviceJourneys\":[{\"estimatedCalls\":[{\"aimedArrivalTime\":\"2025-07-21T08:36:00+02:00\",\"cancellation\":false,\"date\":\"2025-07-21\",\"expectedArrivalTime\":\"2025-07-21T08:03:44+02:00\",\"realtime\":true,\"realtimeState\":\"updated\",\"actualArrivalTime\":\"2025-07-21T08:03:44+02:00\"}]}]}]}"
+
+  let result =
+    json.parse(from: json_string, using: entur_decoder.data_decoder())
+
+  let expected =
+    Ok(
+      Data([
+        Line("GOA:Line:50", [
+          ServiceJourney([
+            EstimatedCall(
+              "2025-07-21T08:36:00+02:00",
+              False,
+              "2025-07-21",
+              "2025-07-21T08:03:44+02:00",
+              True,
+              "updated",
+              option.Some("2025-07-21T08:03:44+02:00"),
+            ),
+          ]),
+        ]),
+      ]),
+    )
+
+  should.equal(result, expected)
 }


### PR DESCRIPTION
- Change actual_arrival_time to an optional field in entur_decoder to
  correctly handle null values from the API.
- Fix JSON decoding to match updated API response structure.
- Add tests covering cases with null and present actual arrival times.
- Adjust entur_client filtering logic to use option.is_none instead of
  string.is_empty for actual_arrival_time.
- Lower delay threshold from 15 to 5 minutes and add debug logging.
- Temporarily disable delay notice rendering and related delayed_subject
  handling due to API changes.
- Remove unused imports and clean up code for clarity and correctness.