### PR TITLE
feat: add custom 404 page with user-friendly message

### DIFF
--- a/src/not_found.gleam
+++ b/src/not_found.gleam
@@ -1,0 +1,28 @@
+import lustre/attribute.{class, href}
+import lustre/element.{type Element}
+import lustre/element/html
+
+pub fn render() -> Element(msg) {
+  html.div([class("text-center py-16")], [
+    html.h1(
+      [class("text-4xl font-bold tracking-tight text-gray-900 sm:text-5xl")],
+      [element.text("404 - Siden var ikke på stasjonen")],
+    ),
+    html.p([class("mt-6 text-base leading-7 text-gray-600")], [
+      element.text(
+        "Siden du lette etter tok Sørtoget og kom dessverre ikke frem. Vi sjekket stasjonen, men vi kunne ikke finne den.",
+      ),
+    ]),
+    html.div([class("mt-10 flex items-center justify-center gap-x-6")], [
+      html.a(
+        [
+          href("/"),
+          class(
+            "rounded-md bg-indigo-600 px-3.5 py-2.5 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600",
+          ),
+        ],
+        [element.text("Gå tilbake til forsiden")],
+      ),
+    ]),
+  ])
+}

--- a/src/surtoget.gleam
+++ b/src/surtoget.gleam
@@ -18,6 +18,7 @@ import lustre/element/html
 import marceau
 import mist
 import news
+import not_found
 import simplifile
 import wisp.{type Request, type Response}
 import wisp/internal
@@ -62,7 +63,15 @@ pub fn handle_request(req: Request, ctx: Context) -> Response {
   use <- wisp.serve_static(req, under: "/static", from: "priv/static")
   use <- wisp.serve_static(req, under: "/css", from: "priv/css")
   use <- wisp.serve_static(req, under: "/javascript", from: "priv/javascript")
-  route_request(req, ctx)
+  case route_request(req, ctx) {
+    response if response.status == 404 -> {
+      let page = render_page(not_found.render())
+      wisp.not_found()
+      |> wisp.set_body(page.body)
+      |> wisp.set_header("content-type", "text/html; charset=utf-8")
+    }
+    response -> response
+  }
 }
 
 fn route_request(req: Request, ctx: Context) -> Response {


### PR DESCRIPTION
Create a new not_found module that renders a styled 404 error page
informing users that the requested page was not found. Update the main
request handler to detect 404 responses and replace them with the
custom page, improving user experience by providing clear navigation
back to the homepage.