### PR TITLE
perf: increase VM memory allocation to 512mb

### DIFF
--- a/fly.toml
+++ b/fly.toml
@@ -24,6 +24,6 @@ method = 'GET'
 path = '/health'
 
 [[vm]]
-memory = '256mb'
+memory = '512mb'
 cpu_kind = 'shared'
 cpus = 1


### PR DESCRIPTION
Increase the memory allocation for the VM from 256mb to 512mb to
improve performance and ensure better stability under load. This
change helps prevent potential memory-related issues during runtime.