### PR TITLE
feat(faq, stories): add Google Forms option for story submissions

### DIFF
--- a/src/faq.gleam
+++ b/src/faq.gleam
@@ -32,10 +32,15 @@ pub fn render() -> Element(msg) {
     Question(
       "Hvordan kan jeg dele min historie?",
       [
-        "Du kan sende din historie til oss på e-post til kontakt@surtoget.no. Vi publiserer historier fortløpende.",
-        "Du kan velge å være anonym, og e-posten din blir slettet etter en uke. Vi forbeholder oss retten til å redigere og korrigere stavefeil, men vi vil ikke skrive om historien din. Hvis du vil ha historien din slettet, kan du kontakte oss på samme e-postadresse.",
+        "Du kan sende din historie til oss via Google Forms eller på e-post til kontakt@surtoget.no. Vi publiserer historier fortløpende.",
+        "Du kan velge å være anonym. Innsendinger via Google-skjema og e-post blir slettet etter en uke. Vi forbeholder oss retten til å redigere og korrigere stavefeil, men vi vil ikke skrive om historien din. Hvis du vil ha historien din slettet, kan du kontakte oss på samme e-postadresse.",
       ],
-      [],
+      [
+        #(
+          "https://docs.google.com/forms/d/e/1FAIpQLSe_x8FSwMMBNf6l_EOhfF2x8ieLVVOKNF6482n4Jfxtqg89oA/viewform?usp=header",
+          "Skjema for historier",
+        ),
+      ],
     ),
     Question(
       "Hvorfor bare Sørlandsbanen?",

--- a/src/stories.gleam
+++ b/src/stories.gleam
@@ -1,5 +1,5 @@
 import gleam/list
-import lustre/attribute.{class, href}
+import lustre/attribute.{class, href, target}
 import lustre/element.{type Element}
 import lustre/element/html
 
@@ -90,10 +90,22 @@ pub fn render() -> Element(a) {
       ]),
       html.div([class("mt-12 text-center")], [
         html.p([class("text-gray-600")], [
-          html.text("Har du en egen historie du vil dele? Send den til "),
+          html.text("Har du en egen historie du vil dele? Send den inn via "),
+          html.a(
+            [
+              target("_blank"),
+              href(
+                "https://docs.google.com/forms/d/e/1FAIpQLSe_x8FSwMMBNf6l_EOhfF2x8ieLVVOKNF6482n4Jfxtqg89oA/viewform?usp=header",
+              ),
+              class("text-yellow-600 hover:underline"),
+            ],
+            [html.text("dette skjemaet")],
+          ),
+          html.text(" eller send den til "),
           html.a(
             [
               href("mailto:kontakt@surtoget.no"),
+              target("_blank"),
               class("text-yellow-600 hover:underline"),
             ],
             [html.text("kontakt@surtoget.no")],


### PR DESCRIPTION
Update FAQ and story submission UI to include a Google Forms link
as an alternative to email. Clarify that submissions via both methods
are deleted after one week. Add target="_blank" to external links
to open them in new tabs for better user experience. This improves
accessibility and provides a more convenient way for users to share
their stories.