### PR TITLE
feat(perf): add request duration logging middleware

### DIFF
--- a/src/perf_logging.gleam
+++ b/src/perf_logging.gleam
@@ -1,0 +1,35 @@
+import gleam/http
+import gleam/int
+import gleam/string
+import tempo/duration
+import tempo/instant
+import wisp
+
+pub fn log_request_duration(
+  handler: fn(wisp.Request) -> wisp.Response,
+) -> fn(wisp.Request) -> wisp.Response {
+  fn(req) {
+    let start_time = instant.now()
+    let response = handler(req)
+    let end_time = instant.now()
+    let duration =
+      instant.difference(start_time, end_time) |> duration.as_microseconds()
+
+    let msg: String =
+      string.concat([
+        req.method |> http.method_to_string(),
+        " ",
+        req.path,
+        " took ",
+        int.to_string(duration),
+        "ms",
+      ])
+
+    case duration {
+      duration if duration > 500 -> wisp.log_warning(msg)
+      _ -> wisp.log_info(msg)
+    }
+
+    response
+  }
+}

--- a/src/surtoget.gleam
+++ b/src/surtoget.gleam
@@ -19,6 +19,7 @@ import marceau
 import mist
 import news
 import not_found
+import perf_logging
 import simplifile
 import wisp.{type Request, type Response}
 import wisp/internal
@@ -49,8 +50,9 @@ pub fn main() -> Nil {
       faq_page: render_page(faq.render()),
       news_page: news.get_news_articles() |> news.render() |> render_page(),
     )
+  let router = handle_request(_, ctx) |> perf_logging.log_request_duration()
   let assert Ok(_) =
-    wisp_mist.handler(handle_request(_, ctx), secret_key_base)
+    wisp_mist.handler(router, secret_key_base)
     |> mist.new()
     |> mist.bind("0.0.0.0")
     |> mist.port(8000)


### PR DESCRIPTION
Introduce a middleware function that logs the duration of each HTTP
request. Requests taking longer than 500ms are logged as warnings,
while others are logged as info. This helps monitor performance and
identify slow requests.

Integrate the middleware into the main router to automatically log
all incoming requests without changing existing handler logic.