### PR TITLE
feat: add lazy loading to images for better performance

### DIFF
--- a/src/news.gleam
+++ b/src/news.gleam
@@ -1,6 +1,6 @@
 import gleam/bit_array
 import gleam/list
-import lustre/attribute.{alt, class, href, rel, src, target}
+import lustre/attribute.{alt, class, href, loading, rel, src, target}
 import lustre/element.{type Element}
 import lustre/element/html
 
@@ -283,6 +283,7 @@ pub fn render(articles: List(NewsArticle)) -> Element(a) {
             [
               html.div([class("md:w-1/3")], [
                 html.img([
+                  loading("lazy"),
                   src(get_image_url(article)),
                   alt(article.title),
                   class("w-full h-full object-cover max-h-80 md:max-h-full"),

--- a/src/news_page.gleam
+++ b/src/news_page.gleam
@@ -36,6 +36,7 @@ pub fn render(articles: List(NewsArticle)) -> Element(a) {
           ],
           [
             html.img([
+              attribute.loading("lazy"),
               attribute.src(news.get_image_url(article)),
               attribute.alt(article.title),
               attribute.class("w-full h-48 max-h-48 object-cover"),


### PR DESCRIPTION
Add the loading="lazy" attribute to img elements in news.gleam and
news_page.gleam to defer offscreen image loading. This improves page
load times and reduces initial data usage by loading images only when
they are about to enter the viewport. Also update imports to include
the loading attribute for proper usage.