### PR TITLE
fix(perf_logging): measure duration in milliseconds instead of microseconds

### DIFF
--- a/src/perf_logging.gleam
+++ b/src/perf_logging.gleam
@@ -13,7 +13,7 @@ pub fn log_request_duration(
     let response = handler(req)
     let end_time = instant.now()
     let duration =
-      instant.difference(start_time, end_time) |> duration.as_microseconds()
+      instant.difference(start_time, end_time) |> duration.as_milliseconds()
 
     let msg: String =
       string.concat([


### PR DESCRIPTION
Change the duration calculation from microseconds to milliseconds to provide
a more appropriate time unit for performance logging. This improves the
readability and relevance of logged timing data.