### PR TITLE
feat(header): add aria-label to menu button for accessibility

### DIFF
--- a/src/header.gleam
+++ b/src/header.gleam
@@ -35,6 +35,7 @@ pub fn render() -> Element(msg) {
             [
               attribute("id", "menu-button"),
               attribute("type", "button"),
+              attribute("aria-label", "Toggle navigation menu"),
               class(
                 "text-gray-500 hover:text-yellow-600 focus:outline-none focus:text-yellow-600",
               ),


### PR DESCRIPTION
Add an aria-label attribute to the menu button to improve
accessibility by providing a descriptive label for screen readers.