### PR TITLE
chore(fly.toml): update machine and health check settings

### DIFF
--- a/fly.toml
+++ b/fly.toml
@@ -13,15 +13,15 @@ internal_port = 8000
 force_https = true
 auto_stop_machines = 'suspend'
 auto_start_machines = true
-min_machines_running = 1
+min_machines_running = 0
 processes = ['app']
 
 [[http_service.checks]]
-interval = '30s'
-timeout = '5s'
-grace_period = '15s'
-method = 'GET'
-path = '/health'
+grace_period = "5s"
+interval = "5s"
+method = "GET"
+timeout = "2s"
+path = "/health"
 
 [[vm]]
 memory = '512mb'


### PR DESCRIPTION
Set min_machines_running to 0 to allow zero machines running when idle. Adjust health check parameters to reduce grace period, interval, and timeout for faster detection of unhealthy instances. These changes improve resource efficiency and responsiveness of the app deployment.