### PR TITLE
feat: replace actor state with ETS cache for delay tracking

### DIFF
--- a/src/delayed.gleam
+++ b/src/delayed.gleam
@@ -5,66 +5,69 @@
 //// Right now we will only hold a boolean, but in the future we might hold more data.
 
 import entur_client
+import gleam/erlang/atom
 import gleam/erlang/process
-import gleam/otp/actor
 import wisp
+
+@external(erlang, "ets_cache", "new")
+pub fn new_cache(name: atom.Atom) -> Result(atom.Atom, atom.Atom)
+
+@external(erlang, "ets_cache", "insert")
+pub fn insert(
+  tid: atom.Atom,
+  key: atom.Atom,
+  value: Bool,
+) -> Result(Nil, atom.Atom)
+
+@external(erlang, "ets_cache", "lookup")
+pub fn lookup(tid: atom.Atom, key: atom.Atom) -> Result(Bool, atom.Atom)
 
 // 5 minutes in ms
 const wait_time_ms = 300_000
 
+const delated_ets_key: String = "has_delays"
+
 // Starts a very simple scheduled process that kics inn every 5 minutes
-pub fn start() -> Result(
-  actor.Started(process.Subject(DelayMessage)),
-  actor.StartError,
-) {
-  let start_result =
-    actor.new(State(False))
-    |> actor.on_message(handle_message)
-    |> actor.start()
-  case start_result {
-    Ok(result) -> {
-      process.spawn(fn() { scheduler(result.data) })
-      start_result
+pub fn start() -> Result(atom.Atom, atom.Atom) {
+  let cache_name = atom.create("delayed_cache")
+  case new_cache(cache_name) {
+    Ok(tid) -> {
+      process.spawn(fn() { scheduler(tid) })
+      Ok(tid)
     }
-    Error(_) -> start_result
+    Error(reason) -> Error(reason)
   }
 }
 
-pub fn is_delayed(subject: process.Subject(DelayMessage)) -> Bool {
-  process.call(subject, 100, fn(reply_to) { GetState(reply_to) })
+pub fn is_delayed(tid: atom.Atom) -> Bool {
+  case lookup(tid, atom.create(delated_ets_key)) {
+    Ok(value) -> value
+    Error(_) -> False
+  }
 }
 
-fn scheduler(subject: process.Subject(DelayMessage)) {
+fn scheduler(tid: atom.Atom) {
   wisp.log_info("Running delayed update check...")
   // Spawning a new unlinked process to avoid any issues propagating
   process.spawn_unlinked(fn() {
-    update(subject)
-    wisp.log_info("Update check ran successfully")
+    case update(tid) {
+      Ok(_) -> wisp.log_info("Update check ran successfully")
+      Error(_) -> wisp.log_error("Failed to update delay status")
+    }
   })
   process.sleep(wait_time_ms)
-  scheduler(subject)
+  scheduler(tid)
 }
 
-fn update(subject: process.Subject(DelayMessage)) {
-  let has_delays = entur_client.is_train_delayed()
-  process.send(subject, SetState(State(has_delays)))
-}
-
-pub type State {
-  State(has_delay: Bool)
-}
-
-pub type DelayMessage {
-  SetState(State)
-  GetState(process.Subject(Bool))
-}
-
-fn handle_message(state: State, message: DelayMessage) {
-  case message {
-    SetState(state) -> actor.continue(state)
-    GetState(reply_to) -> {
-      process.send(reply_to, state.has_delay)
-      actor.continue(state)
+fn update(tid: atom.Atom) -> Result(Nil, Nil) {
+  case entur_client.is_train_delayed() {
+    Ok(has_delays) -> {
+      let _ = insert(tid, atom.create(delated_ets_key), has_delays)
+      Ok(Nil)
+    }
+    Error(_) -> {
+      wisp.log_error("Failed to check for delays")
+      Error(Nil)
     }
   }
 }

--- a/src/ets_cache.erl
+++ b/src/ets_cache.erl
@@ -1,0 +1,42 @@
+-module(ets_cache).
+
+-export([new/1, insert/3, lookup/2]).
+
+new(Name) ->
+  try
+    {ok, ets:new(Name, [set, public, named_table, {read_concurrency, true}])}
+  catch
+    _:badarg ->
+      % This error can happen if the table name is not an atom,
+      % or if the table already exists. We check for the latter.
+      case ets:whereis(Name) of
+        undefined ->
+          % Table does not exist, so it must be a different badarg error.
+          {error, {erlang_error, atom_to_binary(badarg, utf8)}};
+        _ ->
+          % Table already exists, which is fine for our use case.
+          {ok, Name}
+      end;
+    _:Reason ->
+      {error, {erlang_error, atom_to_binary(Reason, utf8)}}
+  end.
+
+insert(Tid, Key, Value) ->
+  try ets:insert(Tid, {Key, Value}) of
+    _ ->
+      {ok, nil}
+  catch
+    _:Reason ->
+      {error, {erlang_error, term_to_binary(Reason)}}
+  end.
+
+lookup(Tid, Key) ->
+  try ets:lookup(Tid, Key) of
+    [{_, Value}] ->
+      {ok, Value};
+    [] ->
+      {error, empty}
+  catch
+    _:Reason ->
+      {error, {erlang_error, term_to_binary(Reason)}}
+  end.

--- a/src/index.gleam
+++ b/src/index.gleam
@@ -1,5 +1,5 @@
 import delayed
-import gleam/erlang/process
+import gleam/erlang/atom
 import gleam/list
 import lustre/attribute.{attribute, class, src}
 import lustre/element.{type Element}
@@ -9,15 +9,13 @@ import refund
 import statistics
 import stories
 
-pub fn render(
-  delayed_subject: process.Subject(delayed.DelayMessage),
-) -> Element(msg) {
+pub fn render(delayed_tid: atom.Atom) -> Element(msg) {
   let articles = news.get_news_articles()
   let latest_news = list.take(articles, 3)
 
   html.main([class("my-10 space-y-16")], [
     blurb(),
-    render_delay_notice(delayed_subject),
+    render_delay_notice(delayed_tid),
     html.section([], [statistics.render()]),
     html.section([], [refund.render()]),
     html.section([], [stories.render()]),
@@ -26,10 +24,8 @@ pub fn render(
 }
 
 //TODO Temporary removed due to using the wrong API 🤷🏻‍♂️
-fn render_delay_notice(
-  delayed_subject: process.Subject(delayed.DelayMessage),
-) -> Element(msg) {
-  case delayed.is_delayed(delayed_subject) {
+fn render_delay_notice(delayed_tid: atom.Atom) -> Element(msg) {
+  case delayed.is_delayed(delayed_tid) {
     True ->
       html.div([class("my-10 p-4 bg-yellow-100 rounded-lg shadow-md")], [
         html.p(

--- a/src/surtoget.gleam
+++ b/src/surtoget.gleam
@@ -3,6 +3,7 @@ import delayed
 import faq
 import footer
 import gleam/bytes_tree
+import gleam/erlang/atom
 import gleam/erlang/process
 import gleam/http/request
 import gleam/http/response
@@ -28,7 +29,7 @@ import wisp/wisp_mist
 pub type Context {
   Context(
     image_cache_subject: process.Subject(image_cache.ImageCacheMessage),
-    delayed_subject: process.Subject(delayed.DelayMessage),
+    delayed_subject: atom.Atom,
     // Some pages are fully static, so we might as well pre-render them on startup
     // just to avoid doing extra processing (despite it being pretty fast anyway)
     about_page: response.Response(wisp.Body),
@@ -45,7 +46,7 @@ pub fn main() -> Nil {
   let ctx =
     Context(
       image_cache_subject: cache.data,
-      delayed_subject: delayed.data,
+      delayed_subject: delayed,
       about_page: render_page(about.render()),
       faq_page: render_page(faq.render()),
       news_page: news.get_news_articles() |> news.render() |> render_page(),


### PR DESCRIPTION
Refactor delayed module to use an ETS-based cache instead of an OTP actor
to store and retrieve delay status. This simplifies state management by
removing message passing and leveraging Erlang's ETS for efficient shared
state. Add a new ets_cache Erlang module to handle ETS operations safely.

Update entur_client to return Result for delay checks, improving error
handling. Modify render and context to use the new cache-based API.

This change improves performance, reduces complexity, and prepares for
future extensions of delay data storage beyond a boolean flag.