### PR TITLE
wip: short-circuit mise dependencies

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -50,8 +50,8 @@ outputs = ["node_modules", "package.json"]
 description = "generate css"
 depends = ["deps"]
 run = "npx tailwindcss -o ./priv/css/tailwind.css && gzip -k -f ./priv/css/tailwind.css"
-sources = ["priv"]
-outputs = ["priv"]
+sources = ["src"]
+outputs = ["priv/css"]
 
 [tasks.format]
 description = "gleam format"

--- a/mise.toml
+++ b/mise.toml
@@ -57,8 +57,6 @@ outputs = ["priv/css"]
 description = "gleam format"
 depends = ["deps"]
 run = "gleam format"
-sources = ["src"]
-outputs = ["src"]
 
 [tasks.run]
 description = "gleam run"

--- a/mise.toml
+++ b/mise.toml
@@ -43,28 +43,24 @@ EOF
 [tasks.deps]
 description = "install npm dependencies"
 run = "npm install"
+sources = ["node_modules", "package.json"]
+outputs = ["node_modules", "package.json"]
 
 [tasks.css]
 description = "generate css"
 depends = ["deps"]
 run = "npx tailwindcss -o ./priv/css/tailwind.css && gzip -k -f ./priv/css/tailwind.css"
-
-[tasks.new]
-description = "generate new project [NAME] from template"
-depends = ["css"]
-run = '''
-gleam new --template=surtoget $1
-cd $1
-gleam run
-'''
+sources = ["priv"]
+outputs = ["priv"]
 
 [tasks.format]
 description = "gleam format"
-depends = ["css"]
+depends = ["deps"]
 run = "gleam format"
+sources = ["src"]
+outputs = ["src"]
 
 [tasks.run]
 description = "gleam run"
-depends = ["format"]
+depends = ["deps", "format", "css"]
 run = "gleam run"
-

--- a/mise.toml
+++ b/mise.toml
@@ -43,8 +43,8 @@ EOF
 [tasks.deps]
 description = "install npm dependencies"
 run = "npm install"
-sources = ["node_modules", "package.json"]
-outputs = ["node_modules", "package.json"]
+sources = ["package.json"]
+outputs = ["node_modules", "package-lock.json"]
 
 [tasks.css]
 description = "generate css"


### PR DESCRIPTION
* optimize mise dependency graph
* skip invoking targets for unchanged inputs and outputs

@lpil and @atomfinger  I'm not sure I have this quite right. When I look at the output it seems that only the `deps` target is getting skipped. Take a look at the input/output files for the other targets and see if you can help me out there:

this is working as expected:

```
[deps] sources up-to-date, skipping
```

i'm expecting these two to also be skipped:

```
[format] $ gleam format
[css] $ npx tailwindcss -o ./priv/css/tailwind.css && gzip -k -f ./priv/css/tailwind.css
```

REPRO

```
repos/personal/gleam/surtoget$ mise run run
[deps] sources up-to-date, skipping
[format] $ gleam format
[css] $ npx tailwindcss -o ./priv/css/tailwind.css && gzip -k -f ./priv/css/tailwind.css
[format] Finished in 31.8ms
[css] Browserslist: caniuse-lite is outdated. Please run:
[css]   npx update-browserslist-db@latest
[css]   Why you should do it regularly: https://github.com/browserslist/update-db#readme
[css] 
[css] Rebuilding...
[css] 
[css] Done in 120ms.
[css] Finished in 390.0ms
[run] $ gleam run
[run]    Compiled in 0.04s
[run]     Running surtoget.main
[run] INFO Running delayed update check...
[run] Listening on http://0.0.0.0:8000
[run] INFO Update check ran successfully
[run] WARN retry: got exception, will retry in 1000ms, 3 attempts left
[run] WARN ** (Req.TransportError) timeout
[run] INFO GET / took 12ms
[run] INFO GET /javascript/main.js took 5ms
[run] INFO GET /css/tailwind.css took 5ms
[run] INFO GET /static/banenor_logo.webp took 0ms
[run] INFO GET /static/goahead_logo.webp took 0ms
[run] EROR Failed to send file: SocketErr(Closed)
[run] EROR Failed to send file: SocketErr(Closed)
^C
mise WARN  Ctrl-C pressed, please wait for tasks to finish or press Ctrl-C again to force exit
[run] 
[run] BREAK: (a)bort (A)bort with dump (c)ontinue (p)roc info (i)nfo
[run]        (l)oaded (v)ersion (k)ill (D)b-tables (d)istribution
[run] ERROR sh exited with non-zero status: no exit status
Finished in 48.03s
[run] ERROR task failed

```