### PR TITLE
feat(image_cache): replace actor with ETS-based cache for images

### DIFF
--- a/src/gets.gleam
+++ b/src/gets.gleam
@@ -1,6 +1,4 @@
 import gleam/erlang/atom
-import gleam/http/response
-import wisp
 
 @external(erlang, "ets_cache", "new")
 pub fn new_cache(name: atom.Atom) -> Result(atom.Atom, atom.Atom)
@@ -9,11 +7,8 @@ pub fn new_cache(name: atom.Atom) -> Result(atom.Atom, atom.Atom)
 pub fn insert(
   tid: atom.Atom,
   key: atom.Atom,
-  value: response.Response(wisp.Body),
+  value: v,
 ) -> Result(Nil, atom.Atom)
 
 @external(erlang, "ets_cache", "lookup")
-pub fn lookup(
-  tid: atom.Atom,
-  key: atom.Atom,
-) -> Result(response.Response(wisp.Body), atom.Atom)
+pub fn lookup(tid: atom.Atom, key: atom.Atom) -> Result(v, atom.Atom)


### PR DESCRIPTION
Refactor image caching to use an ETS-backed cache via the `gets` module instead of an actor-based message system. This change improves concurrency and performance by eliminating actor message passing and leveraging Erlang's efficient ETS storage. The image cache now starts an ETS table and spawns async image loading processes that insert directly into the cache. Lookup functions are updated to query ETS, falling back to a default image on miss.

This simplifies the code by removing the `ImageCacheMessage` type and actor handling, and updates all usages to work with the new ETS cache identifier.