### PR TITLE
chore(config): require one machine to stay running

### DIFF
--- a/fly.toml
+++ b/fly.toml
@@ -13,7 +13,7 @@ internal_port = 8000
 force_https = true
 auto_stop_machines = 'suspend'
 auto_start_machines = true
-min_machines_running = 0
+min_machines_running = 1
 processes = ['app']
 
 [[http_service.checks]]


### PR DESCRIPTION
Increase the minimum number of running machines from 0 to 1 in the
Fly.io configuration to ensure at least one instance remains active.
This prevents downtime during periods when autoscaling would otherwise
suspend all machines and ensures the application stays reachable.