### PR TITLE
feat(news): add new Adressa news article to list

### DIFF
--- a/src/news.gleam
+++ b/src/news.gleam
@@ -25,6 +25,14 @@ import gleam/dict
 pub fn get_news_articles() -> List(NewsArticle) {
   let articles = [
     NewsArticle(
+      title: "Tekniske problemer med fjernstyringen av tog flere steder i landet",
+      description: "Problemer med fjernstyringsanlegget til Bane Nor førte til mindre forsinkelser på Sørlandsbanen, Jærbanen og på tog i drammensregionen lørdag. ",
+      external_url: "https://www.adressa.no/nyheter/innenriks/i/5E2K06/tekniske-problemer-med-fjernstyringen-av-tog-flere-steder-i-landet",
+      external_image_url: "",
+      owner: "Adressa",
+      date: "16. august 2025",
+    ),
+    NewsArticle(
       title: "Visste ikke hvor omfat­tende det var",
       description: "Go-Ahead har fortsatt trøbbel med flere av togene som ble tatt ut av drift i slutten av juli. ",
       external_url: "https://www.aftenbladet.no/lokalt/i/lwdOa9/sliter-fortsatt-visste-ikke-hvor-omfattende-det-var",


### PR DESCRIPTION
Add a NewsArticle entry from Adressa about technical problems with the
remote control system for trains affecting multiple lines (Sørlandsbanen,
Jærbanen and Drammen region). Include title, description, external URL,
empty image URL, owner and date. This restores up-to-date coverage of a
recent incident and ensures the news list includes the new report for
display and linking.