### PR TITLE
fix(server): set file-body range and update HTML rendering

### DIFF
--- a/src/surtoget.gleam
+++ b/src/surtoget.gleam
@@ -129,7 +129,7 @@ fn serve_static_image(req: Request, image_path: String) -> Response {
         simplifile.File -> {
           wisp.response(200)
           |> response.set_header("content-type", mime_type)
-          |> response.set_body(wisp.File(path))
+          |> response.set_body(wisp.File(path, 0, option.None))
           |> handle_etag(req, file_info.size)
         }
         _ -> wisp.not_found()
@@ -222,6 +222,6 @@ fn render_page(content: Element(msg)) -> response.Response(wisp.Body) {
     ])
 
   index_page
-  |> element.to_document_string_tree()
+  |> element.to_string()
   |> wisp.html_response(200)
 }


### PR DESCRIPTION
Set the response body to include an explicit file byte-range by
constructing wisp.File with (path, 0, option.None) instead of the
single-argument form. This ensures the file response includes the
expected start offset and optional end, aligning with the wisp.File
constructor and preventing incorrect body handling.

Also replace element.to_document_string_tree() with element.to_string()
when building the index page HTML. This simplifies the rendering call
to the current element API and yields the correct string to pass to
wisp.html_response.