### PR TITLE
feat(ui): add background page and update navigation; minor fixes

### DIFF
--- a/src/background.gleam
+++ b/src/background.gleam
@@ -1,0 +1,47 @@
+import lustre/attribute.{class}
+import lustre/element.{type Element}
+import lustre/element/html
+
+pub fn render() -> Element(msg) {
+  html.section([class("my-10 space-y-8")], [
+    html.h1([class("text-4xl font-bold text-center text-gray-800")], [
+      html.text("Sørlandsbanens Tilstand"),
+    ]),
+    html.div([class("max-w-2xl mx-auto text-lg text-gray-700 space-y-6")], [
+      html.h2([class("text-2xl font-bold text-gray-800")], [
+        html.text("Fra stolt fortid til usikker fremtid"),
+      ]),
+      html.p([], [
+        html.text(
+          "Sørlandsbanen var en gang en stolt ryggrad i transporten mellom Oslo og Stavanger. I dag er den dessverre blitt et symbol på forfall og frustrasjon for tusenvis av passasjerer. Denne siden forteller historien om hvordan vi kom hit.",
+        ),
+      ]),
+      html.h2([class("text-2xl font-bold text-gray-800")], [
+        html.text("Årsakene til dagens situasjon"),
+      ]),
+      html.p([], [
+        html.text(
+          "Problemene er sammensatte. Flere tiår med manglende investeringer har ført til en utdatert og sårbar infrastruktur. Enkeltspor på lange strekninger, utdaterte signalanlegg og et generelt vedlikeholdsetterslep er bare noen av faktorene.",
+        ),
+      ]),
+      html.p([], [
+        html.text(
+          "Samtidig har oppsplittingen av ansvaret for jernbanen, med Bane NOR som eier av sporet og ulike operatører som kjører togene, skapt en fragmentert og lite effektiv struktur. Dette gjør det vanskelig å gjennomføre de store, helhetlige løftene som trengs.",
+        ),
+      ]),
+      html.h2([class("text-2xl font-bold text-gray-800")], [
+        html.text("Hva må til for en bedre fremtid?"),
+      ]),
+      html.p([], [
+        html.text(
+          "For at Sørlandsbanen skal bli en pålitelig og moderne transportåre igjen, kreves det en massiv og langsiktig satsing. Dobbeltspor på hele eller store deler av strekningen er det viktigste enkelttiltaket. I tillegg må signalanleggene moderniseres og det generelle vedlikeholdsetterslepet tas igjen.",
+        ),
+      ]),
+      html.p([], [
+        html.text(
+          "Det krever politisk vilje og en anerkjennelse av at jernbanen er en kritisk del av landets infrastruktur. Uten en klar og forpliktende plan, vil Sørlandsbanen fortsette å være en kilde til frustrasjon i mange år fremover.",
+        ),
+      ]),
+    ]),
+  ])
+}

--- a/src/header.gleam
+++ b/src/header.gleam
@@ -79,6 +79,7 @@ pub fn render() -> Element(msg) {
               li_nav_item("/", "Hjem"),
               li_nav_item("/news", "Nyheter"),
               li_nav_item("/om-surtoget", "Om Surtoget"),
+              li_nav_item("/background", "Bakgrunn"),
               li_nav_item("/faq", "Ofte stilte spørsmål"),
             ],
           ),

--- a/src/surtoget.gleam
+++ b/src/surtoget.gleam
@@ -7,6 +7,7 @@ import gleam/erlang/process
 import gleam/http/request
 import gleam/http/response
 import gleam/list
+import gleam/option
 import gleam/result
 import gleam/string
 import header
@@ -143,7 +144,7 @@ fn serve_static_image(req: Request, image_path: String) -> Response {
 // on the site. To strike a balance we use a local in-memory cache.
 //
 // The reason we do not use direct links is because we want to be
-// good samaritans and avoid causing unwanted bandwith load due to 
+// good citizens and avoid causing unwanted bandwith load due to
 // direct hotlinking. Read more about it here:
 // https://mailchimp.com/resources/hotlinking/
 //


### PR DESCRIPTION
Add a new Background page describing Sørlandsbanens history, causes of
decline, and proposed remedies. Implement the page as a Lustre
component (background.gleam) with structured headings and paragraphs so
it can be linked from the site.

Update the header navigation to include a "Bakgrunn" link so the new
page is reachable from the site menu.

Import gleam/option in surtoget.gleam and fix a wording typo in a
comment (change "good samaritans" to "good citizens") to improve code
clarity and correctness.