### PR TITLE
fix(nav): remove Background nav item from header

### DIFF
--- a/src/header.gleam
+++ b/src/header.gleam
@@ -79,7 +79,6 @@ pub fn render() -> Element(msg) {
               li_nav_item("/", "Hjem"),
               li_nav_item("/news", "Nyheter"),
               li_nav_item("/om-surtoget", "Om Surtoget"),
-              li_nav_item("/background", "Bakgrunn"),
               li_nav_item("/faq", "Ofte stilte spørsmål"),
             ],
           ),


### PR DESCRIPTION
Remove the "Bakgrunn" (Background) link from the site
header. The link was deleted from the nav items list in header.gleam,
so the Background page no longer appears in the main navigation.

This cleans up the primary menu to reflect the current available
content and avoids linking to a page that should not be directly
accessible from the header.